### PR TITLE
Fix SConscript error when using --wall

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -352,7 +352,7 @@ elif not GetOption('help'):
 
 if not msvc:
 	if platform == "Windows":
-		env.Append(CCFLAGS=['-std=gnu++98'])
+		env.Append(CXXFLAGS=['-std=gnu++98'])
 	else:
 		env.Append(CXXFLAGS=['-std=c++98'])
 	env.Append(CXXFLAGS=['-Wno-invalid-offsetof'])


### PR DESCRIPTION
I was using <code>--wall</code> for no reason and saw this error:
<pre>=====
cc1.exe: error: command line option '-std=gnu++98' is valid for C++/ObjC++ but not for C [-Werror]
cc1.exe: all warnings being treated as errors
=====
</pre>
So here is my patch for that issue.