### PR TITLE
Remove unnecessary pointer checks (attempt 2)

### DIFF
--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -260,8 +260,7 @@ struct PNGChunk
 	}
 	~PNGChunk()
 	{
-		if (Data)
-			delete[] Data;
+		delete[] Data;
 	}
 };
 

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -462,9 +462,9 @@ int register_extension()
 	returnval = 1;
 	finalise:
 
-	if(iconname) free(iconname);
-	if(opencommand) free(opencommand);
-	if(currentfilename) free(currentfilename);
+	free(iconname);
+	free(opencommand);
+	free(currentfilename);
 	
 	return returnval;
 #elif defined(LIN)

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -335,10 +335,10 @@ bool Client::DoInstallation()
 	returnval = 1;
 	finalise:
 
-	if(iconname) free(iconname);
-	if(opencommand) free(opencommand);
-	if(protocolcommand) free(protocolcommand);
-	if(currentfilename) free(currentfilename);
+	free(iconname);
+	free(opencommand);
+	free(protocolcommand);
+	free(currentfilename);
 	
 	return returnval;
 #elif defined(LIN)
@@ -673,8 +673,7 @@ void Client::Tick()
 
 		if(status != 200)
 		{
-			if(data)
-				free(data);
+			free(data);
 		}
 		else if(data)
 		{
@@ -760,8 +759,7 @@ void Client::Tick()
 				//Do nothing
 			}
 
-			if(data)
-				free(data);
+			free(data);
 		}
 	}
 }
@@ -944,7 +942,7 @@ RequestStatus Client::UploadSave(SaveInfo & save)
 	{
 		if(strncmp((const char *)data, "OK", 2)!=0)
 		{
-			if(gameData) delete[] gameData;
+			delete[] gameData;
 			lastError = std::string((const char *)data);
 			free(data);
 			return RequestFailure;
@@ -965,14 +963,14 @@ RequestStatus Client::UploadSave(SaveInfo & save)
 			}
 		}
 		free(data);
-		if(gameData) delete[] gameData;
+		delete[] gameData;
 		return RequestOkay;
 	}
 	else if(data)
 	{
 		free(data);
 	}
-	if(gameData) delete[] gameData;
+	delete[] gameData;
 	return RequestFailure;
 }
 
@@ -1392,8 +1390,7 @@ LoginStatus Client::Login(std::string username, std::string password, User & use
 	{
 		lastError = http_ret_text(dataStatus);
 	}
-	if(data)
-		free(data);
+	free(data);
 	return LoginError;
 }
 
@@ -1439,12 +1436,10 @@ RequestStatus Client::DeleteSave(int saveID)
 		lastError = http_ret_text(dataStatus);
 		goto failure;
 	}
-	if(data)
-		free(data);
+	free(data);
 	return RequestOkay;
 failure:
-	if(data)
-		free(data);
+	free(data);
 	return RequestFailure;
 }
 
@@ -1499,12 +1494,10 @@ RequestStatus Client::AddComment(int saveID, std::string comment)
 		lastError = http_ret_text(dataStatus);
 		goto failure;
 	}
-	if(data)
-		free(data);
+	free(data);
 	return RequestOkay;
 failure:
-	if(data)
-		free(data);
+	free(data);
 	return RequestFailure;
 }
 
@@ -1555,12 +1548,10 @@ RequestStatus Client::FavouriteSave(int saveID, bool favourite)
 		lastError = http_ret_text(dataStatus);
 		goto failure;
 	}
-	if(data)
-		free(data);
+	free(data);
 	return RequestOkay;
 failure:
-	if(data)
-		free(data);
+	free(data);
 	return RequestFailure;
 }
 
@@ -1613,12 +1604,10 @@ RequestStatus Client::ReportSave(int saveID, std::string message)
 		lastError = http_ret_text(dataStatus);
 		goto failure;
 	}
-	if(data)
-		free(data);
+	free(data);
 	return RequestOkay;
 failure:
-	if(data)
-		free(data);
+	free(data);
 	return RequestFailure;
 }
 
@@ -1667,12 +1656,10 @@ RequestStatus Client::UnpublishSave(int saveID)
 		lastError = http_ret_text(dataStatus);
 		goto failure;
 	}
-	if(data)
-		free(data);
+	free(data);
 	return RequestOkay;
 failure:
-	if(data)
-		free(data);
+	free(data);
 	return RequestFailure;
 }
 
@@ -1690,8 +1677,7 @@ RequestStatus Client::PublishSave(int saveID)
 		const char *const postDatas[] = { "" };
 		size_t postLengths[] = { 1 };
 		char *data = http_multipart_post(urlStream.str().c_str(), postNames, postDatas, postLengths, userIDStream.str().c_str(), NULL, authUser.SessionID.c_str(), &dataStatus, NULL);
-		if (data)
-			free(data);
+		free(data);
 	}
 	else
 	{
@@ -1787,7 +1773,7 @@ SaveInfo * Client::GetSave(int saveID, int saveDate)
 	}
 	else
 	{
-		if (data) free(data);
+		free(data);
 		lastError = http_ret_text(dataStatus);
 	}
 	return NULL;
@@ -2000,8 +1986,7 @@ std::vector<SaveComment*> * Client::GetComments(int saveID, int start, int count
 	{
 		lastError = http_ret_text(dataStatus);
 	}
-	if(data)
-		free(data);
+	free(data);
 	return commentArray;
 }
 
@@ -2049,8 +2034,7 @@ std::vector<std::pair<std::string, int> > * Client::GetTags(int start, int count
 	{
 		lastError = http_ret_text(dataStatus);
 	}
-	if(data)
-		free(data);
+	free(data);
 	return tagArray;
 }
 
@@ -2132,8 +2116,7 @@ std::vector<SaveInfo*> * Client::SearchSaves(int start, int count, std::string q
 	{
 		lastError = http_ret_text(dataStatus);
 	}
-	if(data)
-		free(data);
+	free(data);
 	return saveArray;
 }
 
@@ -2321,8 +2304,7 @@ std::list<std::string> * Client::RemoveTag(int saveID, std::string tag)
 	{
 		lastError = http_ret_text(dataStatus);
 	}
-	if(data)
-		free(data);
+	free(data);
 	return tags;
 }
 
@@ -2382,8 +2364,7 @@ std::list<std::string> * Client::AddTag(int saveID, std::string tag)
 	{
 		lastError = http_ret_text(dataStatus);
 	}
-	if(data)
-		free(data);
+	free(data);
 	return tags;
 }
 

--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1075,17 +1075,13 @@ void GameSave::readOPS(char * data, int dataLength)
 fail:
 	//Clean up everything
 	bson_destroy(&b);
-	if(freeIndices)
-		free(freeIndices);
-	if(partsSimIndex)
-		free(partsSimIndex);
+	free(freeIndices);
+	free(partsSimIndex);
 	throw ParseException(ParseException::Corrupt, "Save data corrupt");
 fin:
 	bson_destroy(&b);
-	if(freeIndices)
-		free(freeIndices);
-	if(partsSimIndex)
-		free(partsSimIndex);
+	free(freeIndices);
+	free(partsSimIndex);
 }
 
 void GameSave::readPSv(char * data, int dataLength)
@@ -2191,28 +2187,17 @@ char * GameSave::serialiseOPS(unsigned int & dataLength)
 
 fin:
 	bson_destroy(&b);
-	if(partsData)
-		free(partsData);
-	if(wallData)
-		free(wallData);
-	if(fanData)
-		free(fanData);
-	if (elementCount)
-		delete[] elementCount;
-	if (partsSaveIndex)
-		free(partsSaveIndex);
-	if (soapLinkData)
-		free(soapLinkData);
-	if (partsPosData)
-		free(partsPosData);
-	if (partsPosFirstMap)
-		free(partsPosFirstMap);
-	if (partsPosLastMap)
-		free(partsPosLastMap);
-	if (partsPosCount)
-		free(partsPosCount);
-	if (partsPosLink)
-		free(partsPosLink);
+	free(partsData);
+	free(wallData);
+	free(fanData);
+	delete[] elementCount;
+	free(partsSaveIndex);
+	free(soapLinkData);
+	free(partsPosData);
+	free(partsPosFirstMap);
+	free(partsPosLastMap);
+	free(partsPosCount);
+	free(partsPosLink);
 
 	return (char*)outputData;
 }

--- a/src/client/HTTP.cpp
+++ b/src/client/HTTP.cpp
@@ -552,8 +552,7 @@ int http_async_req_status(void *ctx)
 			{
 				cx->tptr = 0;
 				cx->tlen = 0;
-				if (cx->tbuf)
-					free(cx->tbuf);
+				free(cx->tbuf);
 				cx->state = HTS_RECV;
 			}
 			cx->last = now;
@@ -679,11 +678,9 @@ void http_async_req_close(void *ctx)
 	{
 		cx->keep = 1;
 		tmp = http_async_req_stop(ctx, NULL, NULL);
-		if (tmp)
-			free(tmp);
+		free(tmp);
 	}
-	if (cx->fdhost)
-		free(cx->fdhost);
+	free(cx->fdhost);
 	PCLOSE(cx->fd);
 	free(ctx);
 }
@@ -1083,8 +1080,7 @@ retry:
 	return http_async_req_stop(ctx, ret, len);
 
 fail:
-	if (data)
-		free(data);
+	free(data);
 	if (own_plen)
 		free(plens);
 	if (ret)
@@ -1273,8 +1269,7 @@ retry:
 	return ctx;
 
 fail:
-	if (data)
-		free(data);
+	free(data);
 	if (own_plen)
 		free(plens);
 	//if (ret)

--- a/src/client/SaveFile.cpp
+++ b/src/client/SaveFile.cpp
@@ -65,9 +65,7 @@ void SaveFile::SetDisplayName(std::string displayName)
 }
 
 SaveFile::~SaveFile() {
-	if(gameSave)
-		delete gameSave;
-	if(thumbnail)
-		delete thumbnail;
+	delete gameSave;
+	delete thumbnail;
 }
 

--- a/src/client/SaveInfo.cpp
+++ b/src/client/SaveInfo.cpp
@@ -176,7 +176,6 @@ GameSave * SaveInfo::GetGameSave()
 
 void SaveInfo::SetGameSave(GameSave * saveGame)
 {
-	if(gameSave)
-		delete gameSave;
+	delete gameSave;
 	gameSave = saveGame;
 }

--- a/src/client/requestbroker/APIRequest.cpp
+++ b/src/client/requestbroker/APIRequest.cpp
@@ -61,8 +61,7 @@ RequestBroker::ProcessResponse APIRequest::Process(RequestBroker & rb)
 //#ifdef DEBUG
 				std::cout << typeid(*this).name() << " Request for " << URL << " failed with status " << status << std::endl;
 //#endif	
-				if(data)
-					free(data);
+				free(data);
 
 				return RequestBroker::Failed;
 			}

--- a/src/client/requestbroker/ImageRequest.cpp
+++ b/src/client/requestbroker/ImageRequest.cpp
@@ -76,8 +76,7 @@ RequestBroker::ProcessResponse ImageRequest::Process(RequestBroker & rb)
 	#ifdef DEBUG
 					std::cout << typeid(*this).name() << " Request for " << URL << " failed with status " << status << std::endl;
 	#endif	
-					if(data)
-						free(data);
+					free(data);
 
 					return RequestBroker::Failed;
 				}

--- a/src/client/requestbroker/ThumbRenderRequest.cpp
+++ b/src/client/requestbroker/ThumbRenderRequest.cpp
@@ -38,8 +38,7 @@ RequestBroker::ProcessResponse ThumbRenderRequest::Process(RequestBroker & rb)
 
 ThumbRenderRequest::~ThumbRenderRequest()
 {
-	if(Save)
-		delete Save;
+	delete Save;
 }
 
 void ThumbRenderRequest::Cleanup()

--- a/src/client/requestbroker/WebRequest.cpp
+++ b/src/client/requestbroker/WebRequest.cpp
@@ -60,8 +60,7 @@ RequestBroker::ProcessResponse WebRequest::Process(RequestBroker & rb)
 //#ifdef DEBUG
 				std::cout << typeid(*this).name() << " Request for " << URL << " failed with status " << status << std::endl;
 //#endif	
-				if(data)
-					free(data);
+				free(data);
 
 				return RequestBroker::Failed;
 			}

--- a/src/gui/colourpicker/ColourPickerActivity.cpp
+++ b/src/gui/colourpicker/ColourPickerActivity.cpp
@@ -317,7 +317,6 @@ void ColourPickerActivity::OnDraw()
 }
 
 ColourPickerActivity::~ColourPickerActivity() {
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/console/ConsoleController.cpp
+++ b/src/gui/console/ConsoleController.cpp
@@ -68,8 +68,7 @@ ConsoleView * ConsoleController::GetView()
 ConsoleController::~ConsoleController() {
 	if(ui::Engine::Ref().GetWindow() == consoleView)
 		ui::Engine::Ref().CloseWindow();
-	if(callback)
-		delete callback;
+	delete callback;
 	delete consoleModel;
 	delete consoleView;
 }

--- a/src/gui/dialogues/ConfirmPrompt.cpp
+++ b/src/gui/dialogues/ConfirmPrompt.cpp
@@ -144,7 +144,6 @@ void ConfirmPrompt::OnDraw()
 }
 
 ConfirmPrompt::~ConfirmPrompt() {
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/dialogues/ErrorMessage.cpp
+++ b/src/gui/dialogues/ErrorMessage.cpp
@@ -72,7 +72,6 @@ void ErrorMessage::OnDraw()
 }
 
 ErrorMessage::~ErrorMessage() {
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/dialogues/TextPrompt.cpp
+++ b/src/gui/dialogues/TextPrompt.cpp
@@ -108,7 +108,6 @@ void TextPrompt::OnDraw()
 }
 
 TextPrompt::~TextPrompt() {
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/filebrowser/FileBrowserActivity.cpp
+++ b/src/gui/filebrowser/FileBrowserActivity.cpp
@@ -332,6 +332,5 @@ void FileBrowserActivity::OnDraw()
 
 FileBrowserActivity::~FileBrowserActivity()
 {
-	if(callback)
-		delete callback;
+	delete callback;
 }

--- a/src/gui/game/BitmapBrush.h
+++ b/src/gui/game/BitmapBrush.h
@@ -51,8 +51,7 @@ public:
 	{
 		if(origBitmap)
 		{
-			if(bitmap)
-				delete[] bitmap;
+			delete[] bitmap;
 			bitmap = new unsigned char[size.X*size.Y];
 			if(size == origSize)
 				std::copy(origBitmap, origBitmap+(origSize.X*origSize.Y), bitmap);
@@ -88,8 +87,7 @@ public:
 	}
 	virtual ~BitmapBrush()
 	{
-		if(origBitmap)
-			delete[] origBitmap;
+		delete[] origBitmap;
 	}
 };
 

--- a/src/gui/game/Brush.h
+++ b/src/gui/game/Brush.h
@@ -18,8 +18,7 @@ protected:
 			GenerateBitmap();
 		if(!bitmap)
 			return;
-		if(outline)
-			delete[] outline;
+		delete[] outline;
 		outline = new unsigned char[size.X*size.Y];
 		for(int x = 0; x < size.X; x++)
 		{
@@ -64,10 +63,8 @@ public:
 		updateOutline();
 	}
 	virtual ~Brush() {
-		if(bitmap)
-			delete[] bitmap;
-		if(outline)
-			delete[] outline;
+		delete[] bitmap;
+		delete[] outline;
 	}
 	virtual void RenderRect(Renderer * ren, ui::Point position1, ui::Point position2);
 	virtual void RenderLine(Renderer * ren, ui::Point position1, ui::Point position2);
@@ -75,8 +72,7 @@ public:
 	virtual void RenderFill(Renderer * ren, ui::Point position);
 	virtual void GenerateBitmap()
 	{
-		if(bitmap)
-			delete[] bitmap;
+		delete[] bitmap;
 		bitmap = new unsigned char[size.X*size.Y];
 		for(int x = 0; x < size.X; x++)
 		{

--- a/src/gui/game/EllipseBrush.h
+++ b/src/gui/game/EllipseBrush.h
@@ -14,8 +14,7 @@ public:
 	}
 	virtual void GenerateBitmap()
 	{
-		if(bitmap)
-			delete[] bitmap;
+		delete[] bitmap;
 		bitmap = new unsigned char[size.X*size.Y];
 		int rx = radius.X;
 		int ry = radius.Y;

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -1224,8 +1224,7 @@ void GameController::OpenTags()
 {
 	if(gameModel->GetSave() && gameModel->GetSave()->GetID())
 	{
-		if (tagsWindow)
-			delete tagsWindow;
+		delete tagsWindow;
 		tagsWindow = new TagsController(new TagsCallback(this), gameModel->GetSave());
 		ui::Engine::Ref().ShowWindow(tagsWindow->GetView());
 	}

--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -176,14 +176,10 @@ GameModel::~GameModel()
 	}
 	delete sim;
 	delete ren;
-	if(placeSave)
-		delete placeSave;
-	if(clipboard)
-		delete clipboard;
-	if(currentSave)
-		delete currentSave;
-	if(currentFile)
-		delete currentFile;
+	delete placeSave;
+	delete clipboard;
+	delete currentSave;
+	delete currentFile;
 	//if(activeTools)
 	//	delete[] activeTools;
 }
@@ -556,15 +552,13 @@ void GameModel::SetSave(SaveInfo * newSave)
 {
 	if(currentSave != newSave)
 	{
-		if(currentSave)
-			delete currentSave;
+		delete currentSave;
 		if(newSave == NULL)
 			currentSave = NULL;
 		else
 			currentSave = new SaveInfo(*newSave);
 	}
-	if(currentFile)
-		delete currentFile;
+	delete currentFile;
 	currentFile = NULL;
 
 	if(currentSave && currentSave->GetGameSave())
@@ -599,15 +593,13 @@ void GameModel::SetSaveFile(SaveFile * newSave)
 {
 	if(currentFile != newSave)
 	{
-		if(currentFile)
-			delete currentFile;
+		delete currentFile;
 		if(newSave == NULL)
 			currentFile = NULL;
 		else
 			currentFile = new SaveFile(*newSave);
 	}
-	if (currentSave)
-		delete currentSave;
+	delete currentSave;
 	currentSave = NULL;
 
 	if(newSave && newSave->GetGameSave())
@@ -907,8 +899,7 @@ void GameModel::SetPlaceSave(GameSave * save)
 {
 	if(save != placeSave)
 	{
-		if(placeSave)
-			delete placeSave;
+		delete placeSave;
 		if(save)
 			placeSave = new GameSave(*save);
 		else
@@ -919,8 +910,7 @@ void GameModel::SetPlaceSave(GameSave * save)
 
 void GameModel::SetClipboard(GameSave * save)
 {
-	if(clipboard)
-		delete clipboard;
+	delete clipboard;
 	clipboard = save;
 }
 

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -142,8 +142,7 @@ public:
 	}
 	virtual ~SplitButton()
 	{
-		if(splitActionCallback)
-			delete splitActionCallback;
+		delete splitActionCallback;
 	}
 };
 
@@ -460,8 +459,7 @@ GameView::~GameView()
 
 	}
 
-	if(placeSaveThumb)
-		delete placeSaveThumb;
+	delete placeSaveThumb;
 }
 
 class GameView::MenuAction: public ui::ButtonAction
@@ -728,8 +726,7 @@ void GameView::NotifyToolListChanged(GameModel * sender)
 		tempButton->SetActionCallback(new ToolAction(this, toolList[i]));
 
 		tempButton->Appearance.SetTexture(tempTexture);
-		if(tempTexture)
-			delete tempTexture;
+		delete tempTexture;
 
 		tempButton->Appearance.BackgroundInactive = ui::Colour(toolList[i]->colRed, toolList[i]->colGreen, toolList[i]->colBlue);
 
@@ -1866,8 +1863,7 @@ void GameView::NotifyLogChanged(GameModel * sender, string entry)
 
 void GameView::NotifyPlaceSaveChanged(GameModel * sender)
 {
-	if(placeSaveThumb)
-		delete placeSaveThumb;
+	delete placeSaveThumb;
 	if(sender->GetPlaceSave())
 	{
 		placeSaveThumb = SaveRenderer::Ref().Render(sender->GetPlaceSave());

--- a/src/gui/game/TriangleBrush.h
+++ b/src/gui/game/TriangleBrush.h
@@ -21,8 +21,7 @@ public:
 	};
 	virtual void GenerateBitmap()
 	{
-		if(bitmap)
-			delete[] bitmap;
+		delete[] bitmap;
 		bitmap = new unsigned char[size.X*size.Y];
 		int rx = radius.X;
 		int ry = radius.Y;

--- a/src/gui/interface/Appearance.cpp
+++ b/src/gui/interface/Appearance.cpp
@@ -37,8 +37,7 @@ namespace ui
 
 	void Appearance::SetTexture(VideoBuffer * texture)
 	{
-		if(this->texture)
-			delete this->texture;
+		delete this->texture;
 		if(texture)
 			this->texture = new VideoBuffer(texture);
 		else
@@ -47,8 +46,7 @@ namespace ui
 
 	Appearance::~Appearance()
 	{
-		if(texture)
-			delete texture;
+		delete texture;
 	}
 
 }

--- a/src/gui/interface/AvatarButton.cpp
+++ b/src/gui/interface/AvatarButton.cpp
@@ -25,10 +25,8 @@ AvatarButton::AvatarButton(Point position, Point size, std::string username):
 AvatarButton::~AvatarButton()
 {
 	RequestBroker::Ref().DetachRequestListener(this);
-	if(avatar)
-		delete avatar;
-	if(actionCallback)
-		delete actionCallback;
+	delete avatar;
+	delete actionCallback;
 }
 
 void AvatarButton::Tick(float dt)
@@ -45,8 +43,7 @@ void AvatarButton::OnResponseReady(void * imagePtr, int identifier)
 	VideoBuffer * image = (VideoBuffer*)imagePtr;
 	if(image)
 	{
-		if(avatar)
-			delete avatar;
+		delete avatar;
 		avatar = image;
 	}
 }

--- a/src/gui/interface/Button.cpp
+++ b/src/gui/interface/Button.cpp
@@ -219,15 +219,13 @@ void Button::DoAltAction()
 
 void Button::SetActionCallback(ButtonAction * action)
 {
-	if(actionCallback)
-		delete actionCallback;
+	delete actionCallback;
 	actionCallback = action;
 }
 
 Button::~Button()
 {
-	if(actionCallback)
-		delete actionCallback;
+	delete actionCallback;
 }
 
 } /* namespace ui */

--- a/src/gui/interface/Checkbox.cpp
+++ b/src/gui/interface/Checkbox.cpp
@@ -96,13 +96,11 @@ void Checkbox::Draw(const Point& screenPos)
 
 void Checkbox::SetActionCallback(CheckboxAction * action)
 {
-	if(actionCallback)
-		delete actionCallback;
+	delete actionCallback;
 	actionCallback = action;
 }
 
 Checkbox::~Checkbox() {
-	if(actionCallback)
-		delete actionCallback;
+	delete actionCallback;
 }
 

--- a/src/gui/interface/Component.cpp
+++ b/src/gui/interface/Component.cpp
@@ -239,6 +239,5 @@ void Component::OnMouseWheelInside(int localx, int localy, int d)
 
 Component::~Component()
 {
-	if(menu)
-		delete menu;
+	delete menu;
 }

--- a/src/gui/interface/DropDown.cpp
+++ b/src/gui/interface/DropDown.cpp
@@ -190,8 +190,7 @@ void DropDown::OnMouseLeave(int x, int y)
 
 
 DropDown::~DropDown() {
-	if(callback)
-		delete callback;
+	delete callback;
 }
 
 } /* namespace ui */

--- a/src/gui/interface/Engine.cpp
+++ b/src/gui/interface/Engine.cpp
@@ -39,16 +39,14 @@ Engine::Engine():
 
 Engine::~Engine()
 {
-	if(state_ != NULL)
-		delete state_;
+	delete state_;
 	//Dispose of any Windows.
 	while(!windows.empty())
 	{
 		delete windows.top();
 		windows.pop();
 	}
-	if (lastBuffer)
-		free(lastBuffer);
+	free(lastBuffer);
 }
 
 void Engine::Begin(int width, int height)

--- a/src/gui/interface/Panel.cpp
+++ b/src/gui/interface/Panel.cpp
@@ -46,8 +46,7 @@ Panel::~Panel()
 {
 	for(unsigned i = 0; i < children.size(); ++i)
 	{
-		if( children[i] )
-			delete children[i];
+		delete children[i];
 	}
 #ifdef OGLI
 	glDeleteTextures(1, &myVidTex);

--- a/src/gui/interface/SaveButton.cpp
+++ b/src/gui/interface/SaveButton.cpp
@@ -118,14 +118,10 @@ SaveButton::~SaveButton()
 {
 	RequestBroker::Ref().DetachRequestListener(this);
 
-	if(thumbnail)
-		delete thumbnail;
-	if(actionCallback)
-		delete actionCallback;
-	if(save)
-		delete save;
-	if(file)
-		delete file;
+	delete thumbnail;
+	delete actionCallback;
+	delete save;
+	delete file;
 }
 
 void SaveButton::OnResponseReady(void * imagePtr, int identifier)
@@ -133,8 +129,7 @@ void SaveButton::OnResponseReady(void * imagePtr, int identifier)
 	VideoBuffer * image = (VideoBuffer*)imagePtr;
 	if(image)
 	{
-		if(thumbnail)
-			delete thumbnail;
+		delete thumbnail;
 		thumbnail = image;
 		waitingForThumb = false;
 	}

--- a/src/gui/interface/Slider.cpp
+++ b/src/gui/interface/Slider.cpp
@@ -68,8 +68,7 @@ void Slider::SetColour(Colour col1, Colour col2)
 {
 	pixel pix[2] = {(pixel)PIXRGB(col1.Red, col1.Green, col1.Blue), (pixel)PIXRGB(col2.Red, col2.Green, col2.Blue)};
 	float fl[2] = {0.0f, 1.0f};
-	if(bgGradient)
-		free(bgGradient);
+	free(bgGradient);
 	this->col1 = col1;
 	this->col2 = col2;
 	bgGradient = (unsigned char*)Graphics::GenerateGradient(pix, fl, 2, Size.X-7);

--- a/src/gui/interface/Textbox.cpp
+++ b/src/gui/interface/Textbox.cpp
@@ -35,8 +35,7 @@ Textbox::Textbox(Point position, Point size, std::string textboxText, std::strin
 
 Textbox::~Textbox()
 {
-	if(actionCallback)
-		delete actionCallback;
+	delete actionCallback;
 }
 
 void Textbox::SetHidden(bool hidden)
@@ -566,8 +565,7 @@ Textbox::Textbox(Point position, Point size, std::string textboxText):
 
 Textbox::~Textbox()
 {
-	if(actionCallback)
-		delete actionCallback;
+	delete actionCallback;
 }
 
 void Textbox::TextPosition()

--- a/src/gui/localbrowser/LocalBrowserController.cpp
+++ b/src/gui/localbrowser/LocalBrowserController.cpp
@@ -176,8 +176,7 @@ void LocalBrowserController::Exit()
 LocalBrowserController::~LocalBrowserController() {
 	if(ui::Engine::Ref().GetWindow() == browserView)
 		ui::Engine::Ref().CloseWindow();
-	if(callback)
-		delete callback;
+	delete callback;
 	delete browserModel;
 	delete browserView;
 }

--- a/src/gui/localbrowser/LocalBrowserModel.cpp
+++ b/src/gui/localbrowser/LocalBrowserModel.cpp
@@ -50,8 +50,7 @@ SaveFile * LocalBrowserModel::GetSave()
 
 void LocalBrowserModel::SetSave(SaveFile * newStamp)
 {
-	if(stamp)
-		delete stamp;
+	delete stamp;
 	stamp = new SaveFile(*newStamp);
 }
 
@@ -141,7 +140,6 @@ void LocalBrowserModel::notifySelectedChanged()
 }
 
 LocalBrowserModel::~LocalBrowserModel() {
-	if(stamp)
-		delete stamp;
+	delete stamp;
 }
 

--- a/src/gui/options/OptionsController.cpp
+++ b/src/gui/options/OptionsController.cpp
@@ -105,7 +105,6 @@ OptionsController::~OptionsController() {
 	}
 	delete model;
 	delete view;
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/preview/PreviewController.cpp
+++ b/src/gui/preview/PreviewController.cpp
@@ -192,7 +192,6 @@ PreviewController::~PreviewController() {
 	Client::Ref().RemoveListener(this);
 	delete previewModel;
 	delete previewView;
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/preview/PreviewModel.cpp
+++ b/src/gui/preview/PreviewModel.cpp
@@ -139,14 +139,12 @@ void PreviewModel::OnResponseReady(void * object, int identifier)
 {
 	if (identifier == 1)
 	{
-		if (saveData)
-			delete saveData;
+		delete saveData;
 		saveData = (std::vector<unsigned char>*)object;
 	}
 	if (identifier == 2)
 	{
-		if (save)
-			delete save;
+		delete save;
 		save = (SaveInfo*)object;
 	}
 	if (identifier == 3)
@@ -243,10 +241,8 @@ void PreviewModel::AddObserver(PreviewView * observer)
 PreviewModel::~PreviewModel()
 {
 	RequestBroker::Ref().DetachRequestListener(this);
-	if (save)
-		delete save;
-	if (saveData)
-		delete saveData;
+	delete save;
+	delete saveData;
 	if (saveComments)
 	{
 		for (size_t i = 0; i < saveComments->size(); i++)

--- a/src/gui/preview/PreviewView.cpp
+++ b/src/gui/preview/PreviewView.cpp
@@ -408,8 +408,7 @@ void PreviewView::OnKeyPress(int key, Uint16 character, bool shift, bool ctrl, b
 void PreviewView::NotifySaveChanged(PreviewModel * sender)
 {
 	SaveInfo * save = sender->GetSave();
-	if(savePreview)
-		delete savePreview;
+	delete savePreview;
 	savePreview = NULL;
 	if(save)
 	{
@@ -624,7 +623,6 @@ PreviewView::~PreviewView()
 		RemoveComponent(submitCommentButton);
 		delete submitCommentButton;
 	}
-	if(savePreview)
-		delete savePreview;
+	delete savePreview;
 }
 

--- a/src/gui/render/RenderController.cpp
+++ b/src/gui/render/RenderController.cpp
@@ -59,8 +59,7 @@ RenderController::~RenderController() {
 	{
 		ui::Engine::Ref().CloseWindow();
 	}
-	if(callback)
-		delete callback;
+	delete callback;
 	delete renderModel;
 	delete renderView;
 }

--- a/src/gui/save/LocalSaveActivity.cpp
+++ b/src/gui/save/LocalSaveActivity.cpp
@@ -135,16 +135,13 @@ void LocalSaveActivity::OnDraw()
 
 void LocalSaveActivity::OnResponseReady(void * imagePtr, int identifier)
 {
-	if(thumbnail)
-		delete thumbnail;
+	delete thumbnail;
 	thumbnail = (VideoBuffer*)imagePtr;
 }
 
 LocalSaveActivity::~LocalSaveActivity()
 {
 	RequestBroker::Ref().DetachRequestListener(this);
-	if(thumbnail)
-		delete thumbnail;
-	if(callback)
-		delete callback;
+	delete thumbnail;
+	delete callback;
 }

--- a/src/gui/save/ServerSaveActivity.cpp
+++ b/src/gui/save/ServerSaveActivity.cpp
@@ -358,18 +358,14 @@ void ServerSaveActivity::OnDraw()
 
 void ServerSaveActivity::OnResponseReady(void * imagePtr, int identifier)
 {
-	if(thumbnail)
-		delete thumbnail;
+	delete thumbnail;
 	thumbnail = (VideoBuffer *)imagePtr;
 }
 
 ServerSaveActivity::~ServerSaveActivity()
 {
 	RequestBroker::Ref().DetachRequestListener(this);
-	if(saveUploadTask)
-		delete saveUploadTask;
-	if(callback)
-		delete callback;
-	if(thumbnail)
-		delete thumbnail;
+	delete saveUploadTask;
+	delete callback;
+	delete thumbnail;
 }

--- a/src/gui/search/SearchController.cpp
+++ b/src/gui/search/SearchController.cpp
@@ -99,8 +99,7 @@ void SearchController::Exit()
 
 SearchController::~SearchController()
 {
-	if(activePreview)
-		delete activePreview;
+	delete activePreview;
 	if(ui::Engine::Ref().GetWindow() == searchView)
 	{
 		ui::Engine::Ref().CloseWindow();
@@ -204,8 +203,7 @@ void SearchController::InstantOpen(bool instant)
 
 void SearchController::OpenSave(int saveID)
 {
-	if(activePreview)
-		delete activePreview;
+	delete activePreview;
 	Graphics * g = ui::Engine::Ref().g;
 	g->fillrect(XRES/3, WINDOWH-20, XRES/3, 20, 0, 0, 0, 150); //dim the "Page X of Y" a little to make the CopyTextButton more noticeable
 	activePreview = new PreviewController(saveID, instantOpen, new OpenCallback(this));
@@ -214,8 +212,7 @@ void SearchController::OpenSave(int saveID)
 
 void SearchController::OpenSave(int saveID, int saveDate)
 {
-	if(activePreview)
-		delete activePreview;
+	delete activePreview;
 	Graphics * g = ui::Engine::Ref().g;
 	g->fillrect(XRES/3, WINDOWH-20, XRES/3, 20, 0, 0, 0, 150); //dim the "Page X of Y" a little to make the CopyTextButton more noticeable
 	activePreview = new PreviewController(saveID, saveDate, instantOpen, new OpenCallback(this));

--- a/src/gui/search/SearchModel.cpp
+++ b/src/gui/search/SearchModel.cpp
@@ -278,6 +278,5 @@ void SearchModel::notifySelectedChanged()
 
 SearchModel::~SearchModel()
 {
-	if (loadedSave)
-		delete loadedSave;
+	delete loadedSave;
 }

--- a/src/gui/search/Thumbnail.cpp
+++ b/src/gui/search/Thumbnail.cpp
@@ -68,6 +68,5 @@ void Thumbnail::Resize(ui::Point newSize)
 
 Thumbnail::~Thumbnail()
 {
-	if(Data)
-		delete[] Data;
+	delete[] Data;
 }

--- a/src/gui/tags/TagsController.cpp
+++ b/src/gui/tags/TagsController.cpp
@@ -47,7 +47,6 @@ TagsController::~TagsController() {
 		ui::Engine::Ref().CloseWindow();
 	delete tagsModel;
 	delete tagsView;
-	if(callback)
-		delete callback;
+	delete callback;
 }
 

--- a/src/gui/update/UpdateActivity.cpp
+++ b/src/gui/update/UpdateActivity.cpp
@@ -42,8 +42,7 @@ private:
 		data = http_async_req_stop(request, &status, &dataLength);
 		if (status!=200)
 		{
-			if (data)
-				free(data);
+			free(data);
 			errorStream << "Server responded with Status " << status;
 			notifyError("Could not download update");
 			return false;

--- a/src/lua/LegacyLuaAPI.cpp
+++ b/src/lua/LegacyLuaAPI.cpp
@@ -1944,10 +1944,10 @@ int luatpt_getscript(lua_State* l)
 	}
 
 fin:
-	if(filedata) free(filedata);
-	if(fileuri) delete[] fileuri;
-	if(filename) delete[] filename;
-	if(luacommand) delete[] luacommand;
+	free(filedata);
+	delete[] fileuri;
+	delete[] filename;
+	delete[] luacommand;
 	luacommand = NULL;
 
 	if(lastError)

--- a/src/simulation/CoordStack.h
+++ b/src/simulation/CoordStack.h
@@ -45,7 +45,7 @@ public:
 	}
 	~CoordStack()
 	{
-		if (stack) free(stack);
+		free(stack);
 	}
 	void push(int x, int y)
 	{

--- a/src/simulation/SaveRenderer.cpp
+++ b/src/simulation/SaveRenderer.cpp
@@ -140,8 +140,7 @@ VideoBuffer * SaveRenderer::Render(GameSave * save, bool decorations, bool fire)
 			src+=WINDOWW;
 		}
 		tempThumb = new VideoBuffer(pData, width*CELL, height*CELL);
-		if(pData)
-			free(pData);
+		free(pData);
 #endif
 	}
 	if(doCollapse)


### PR DESCRIPTION
There should be no more spacing issues. Also, I made changes off of the develop branch.

If you're curious here's the script I used:
```ruby
#!/usr/bin/env ruby

Dir.glob("./src/**/*") do |file|
    next if file == '.' or file == '..'

    next if not /.*\.(cpp|h)$/ === file

    text = ""
    File.open(file, "r") do |f|
        text = f.read
        while text.sub!(/(( |\t)*)if ?\((.*)\) ?{?\n?( |\t)*(free ?\(|delete |delete\[\] )(.*)\)?;/, "\\1\\5\\6;") != nil do

            if $3 != ($6.sub(/\)$/, "")) then
                puts file
                STDERR.puts "warning: our \"if\" is different from our \"free\"!"
                STDERR.puts "         \"if (#{$3}) #{$5}#{$6};\""
                STDERR.puts ""
            end
        end
    end

    File.open(file, "w") do |f|
        f.write text
    end
end
```