### PR TITLE
Fixed CLST tmp value carrying over when converted by water

### DIFF
--- a/src/simulation/elements/CLST.cpp
+++ b/src/simulation/elements/CLST.cpp
@@ -62,6 +62,7 @@ int Element_CLST::update(UPDATE_FUNC_ARGS)
 				{
 					if (!(rand()%1500))
 					{
+						parts[i].tmp = 0;
 						sim->part_change_type(i,x,y,PT_PSTS);
 						sim->kill_part(r>>8);
 					}


### PR DESCRIPTION
This is a simple quick fix for a minor bug involving CLST's tmp value (used for color) carrying over onto PSTE when formed. That was mostly harmless, but when PSTE is heated to form BRCK, the bricks get the tmp value too, often resulting in weird speckled coloring, as BRCK has tmp-based coloring too (for PPIP).