### PR TITLE
Fixed FIRE, SMKE, and CO2 passing through the powder-only wall.

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2065,7 +2065,7 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr)
 			return 0;
 		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWLIQUID && elements[pt].Falldown!=2)
 			return 0;
-		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWSOLID && (elements[pt].Falldown!=1 || pt == PT_FIRE || pt == PT_SMKE || pt || PT_CO2))
+		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWSOLID && (elements[pt].Falldown!=1 || pt == PT_FIRE || pt == PT_SMKE || pt == PT_CO2))
 			return 0;
 		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWAIR || bmap[ny/CELL][nx/CELL]==WL_WALL || bmap[ny/CELL][nx/CELL]==WL_WALLELEC)
 			return 0;

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1859,7 +1859,7 @@ bool Simulation::IsWallBlocking(int x, int y, int type)
 			return true;
 		else if (wall == WL_ALLOWLIQUID && elements[type].Falldown!=2)
 			return true;
-		else if (wall == WL_ALLOWSOLID && elements[type].Falldown!=1)
+		else if (wall == WL_ALLOWSOLID && (elements[type].Falldown!=1 || type == PT_CO2 || type == PT_FIRE || type == PT_SMKE))
 			return true;
 		else if (wall == WL_ALLOWAIR || wall == WL_WALL || wall == WL_WALLELEC)
 			return true;
@@ -2065,7 +2065,7 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr)
 			return 0;
 		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWLIQUID && elements[pt].Falldown!=2)
 			return 0;
-		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWSOLID && elements[pt].Falldown!=1)
+		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWSOLID && (elements[pt].Falldown!=1 || pt == PT_FIRE || pt == PT_SMKE || pt || PT_CO2))
 			return 0;
 		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWAIR || bmap[ny/CELL][nx/CELL]==WL_WALL || bmap[ny/CELL][nx/CELL]==WL_WALLELEC)
 			return 0;

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1859,7 +1859,7 @@ bool Simulation::IsWallBlocking(int x, int y, int type)
 			return true;
 		else if (wall == WL_ALLOWLIQUID && elements[type].Falldown!=2)
 			return true;
-		else if (wall == WL_ALLOWSOLID && (elements[type].Falldown!=1 || type == PT_CO2 || type == PT_FIRE || type == PT_SMKE))
+		else if (wall == WL_ALLOWSOLID && elements[type].Falldown!=1)
 			return true;
 		else if (wall == WL_ALLOWAIR || wall == WL_WALL || wall == WL_WALLELEC)
 			return true;
@@ -2065,7 +2065,7 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr)
 			return 0;
 		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWLIQUID && elements[pt].Falldown!=2)
 			return 0;
-		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWSOLID && (elements[pt].Falldown!=1 || pt == PT_FIRE || pt == PT_SMKE || pt == PT_CO2))
+		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWSOLID && elements[pt].Falldown!=1)
 			return 0;
 		if (bmap[ny/CELL][nx/CELL]==WL_ALLOWAIR || bmap[ny/CELL][nx/CELL]==WL_WALL || bmap[ny/CELL][nx/CELL]==WL_WALLELEC)
 			return 0;

--- a/src/simulation/elements/CO2.cpp
+++ b/src/simulation/elements/CO2.cpp
@@ -17,7 +17,7 @@ Element_CO2::Element_CO2()
 	Gravity = 0.1f;
 	Diffusion = 1.0f;
 	HotAir = 0.000f	* CFDS;
-	Falldown = 1;
+	Falldown = 0;
 	
 	Flammable = 0;
 	Explosive = 0;

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -17,7 +17,7 @@ Element_FIRE::Element_FIRE()
 	Gravity = -0.1f;
 	Diffusion = 0.00f;
 	HotAir = 0.001f  * CFDS;
-	Falldown = 1;
+	Falldown = 0;
 	
 	Flammable = 0;
 	Explosive = 0;

--- a/src/simulation/elements/SMKE.cpp
+++ b/src/simulation/elements/SMKE.cpp
@@ -17,7 +17,7 @@ Element_SMKE::Element_SMKE()
 	Gravity = -0.1f;
 	Diffusion = 0.00f;
 	HotAir = 0.001f	* CFDS;
-	Falldown = 1;
+	Falldown = 0;
 	
 	Flammable = 0;
 	Explosive = 0;


### PR DESCRIPTION
Caused by these gasses having a falldown value of 1. Since this may play some role in the behavior of the element (I don't know for sure, but I doubt it after some testing), I opted to change the logic guiding collisions with walls to change this behavior. Also fixed these gasses' ability to be placed inside the powder-only wall too.