### PR TITLE
FREN and FRNL -- Freon and Liquid Freon

### DIFF
--- a/src/simulation/elements/FREN.cpp
+++ b/src/simulation/elements/FREN.cpp
@@ -28,7 +28,7 @@ Element_FREN::Element_FREN()
     
     Temperature = R_TEMP+273.15;
     HeatConduct = 200;
-    Description = "Freon gas. State transitions allow controlled heat flow.";
+    Description = "Freon gas. Can be produced by decompression of liquid freon. State transitions allow controlled heat flow.";
     
     State = ST_GAS;
     Properties = TYPE_GAS|PROP_DEADLY;

--- a/src/simulation/elements/FREN.cpp
+++ b/src/simulation/elements/FREN.cpp
@@ -1,0 +1,61 @@
+#include "simulation/Elements.h"
+//#TPT-Directive ElementClass Element_FREN PT_FREN 179
+Element_FREN::Element_FREN()
+{
+    Identifier = "DEFAULT_PT_FREN";
+    Name = "FREN";
+    Colour = PIXPACK(0x89AE51);
+    MenuVisible = 1;
+    MenuSection = SC_GAS;
+    Enabled = 1;
+    
+    Advection = 1.0f;
+    AirDrag = 0.01f * CFDS;
+    AirLoss = 0.99f;
+    Loss = 0.30f;
+    Collision = -0.1f;
+    Gravity = 0.0f;
+    Diffusion = 1.75f;
+    HotAir = 0.000f	* CFDS;
+    Falldown = 0;
+    
+    Flammable = 3;
+    Explosive = 0;
+    Meltable = 0;
+    Hardness = 3;
+    
+    Weight = 1;
+    
+    Temperature = R_TEMP+53.f+273.15f;
+    HeatConduct = 200;
+    Description = "Freon gas. Releases heat corresponding to its tmp and changes to liquid under pressure.";
+    
+    State = ST_GAS;
+    Properties = TYPE_GAS;
+    
+    LowPressure = IPL;
+    LowPressureTransition = NT;
+    HighPressure = IPH;
+    HighPressureTransition = NT;
+    LowTemperature = ITL;
+    LowTemperatureTransition = NT;
+    HighTemperature = ITH;
+    HighTemperatureTransition = NT;
+    
+    Update = &Element_FREN::update;
+    Graphics = &Element_FREN::graphics;
+}
+
+//#TPT-Directive ElementHeader Element_FREN static int update(UPDATE_FUNC_ARGS)
+int Element_FREN::update(UPDATE_FUNC_ARGS)
+{
+    return 0;
+}
+
+//#TPT-Directive ElementHeader Element_FREN static int graphics(GRAPHICS_FUNC_ARGS)
+int Element_FREN::graphics(GRAPHICS_FUNC_ARGS)
+{
+	return 1;
+}
+
+Element_FREN::~Element_FREN() {}

--- a/src/simulation/elements/FREN.cpp
+++ b/src/simulation/elements/FREN.cpp
@@ -26,12 +26,12 @@ Element_FREN::Element_FREN()
     
     Weight = 1;
     
-    Temperature = R_TEMP+53.f+273.15f;
+    Temperature = R_TEMP+273.15f;
     HeatConduct = 200;
-    Description = "Freon gas. State transitions allow special heat flow.";
+    Description = "Freon gas. State transitions allow controlled heat flow.";
     
     State = ST_GAS;
-    Properties = TYPE_GAS|PROP_LIFE_DEC|PROP_LIFE_KILL_DEC;
+    Properties = TYPE_GAS|PROP_DEADLY;
     
     LowPressure = IPL;
     LowPressureTransition = NT;

--- a/src/simulation/elements/FREN.cpp
+++ b/src/simulation/elements/FREN.cpp
@@ -51,8 +51,8 @@ int Element_FREN::update(UPDATE_FUNC_ARGS)
 {
 	if (sim->pv[y/CELL][x/CELL] > 15.0f)
 	{
-		parts[i].temp += parts[i].tmp;
-		parts[i].tmp = 0;
+		parts[i].temp += sim->pv[y/CELL][x/CELL] * 1.25f;
+		parts[i].tmp = sim->pv[y/CELL][x/CELL] * 1.25f;
 		sim->part_change_type(i, parts[i].x, parts[i].y, PT_FRNL); //Can't use normal transitions due to the above code needing to run first
 	}
 	int r, rx, ry;

--- a/src/simulation/elements/FREN.cpp
+++ b/src/simulation/elements/FREN.cpp
@@ -26,7 +26,7 @@ Element_FREN::Element_FREN()
     
     Weight = 1;
     
-    Temperature = R_TEMP+273.15f;
+    Temperature = R_TEMP+273.15;
     HeatConduct = 200;
     Description = "Freon gas. State transitions allow controlled heat flow.";
     
@@ -49,11 +49,11 @@ Element_FREN::Element_FREN()
 //#TPT-Directive ElementHeader Element_FREN static int update(UPDATE_FUNC_ARGS)
 int Element_FREN::update(UPDATE_FUNC_ARGS)
 {
-	if (sim->pv[y/CELL][x/CELL] > 5.0f)
+	if (sim->pv[y/CELL][x/CELL] > 15.0f)
 	{
 		parts[i].temp += parts[i].tmp;
 		parts[i].tmp = 0;
-		sim->part_change_type(i, parts[i].x, parts[i].y, PT_WATR); //Can't use normal transitions due to the above code needing to run first. PT_WATR is a placeholder.
+		sim->part_change_type(i, parts[i].x, parts[i].y, PT_FRNL); //Can't use normal transitions due to the above code needing to run first
 	}
 	int r, rx, ry;
 	for (rx=-1; rx<2; rx++)

--- a/src/simulation/elements/FRNL.cpp
+++ b/src/simulation/elements/FRNL.cpp
@@ -1,0 +1,61 @@
+#include "simulation/Elements.h"
+//#TPT-Directive ElementClass Element_FRNL PT_FRNL 180
+Element_FRNL::Element_FRNL()
+{
+	Identifier = "DEFAULT_PT_FRNL";
+	Name = "FRNL";
+	Colour = PIXPACK(0x6E8B41);
+	MenuVisible = 1;
+	MenuSection = SC_LIQUID;
+	Enabled = 1;
+	
+	Advection = 0.6f;
+	AirDrag = 0.01f * CFDS;
+	AirLoss = 0.98f;
+	Loss = 0.95f;
+	Collision = 0.0f;
+	Gravity = 0.1f;
+	Diffusion = 0.00f;
+	HotAir = 0.000f	* CFDS;
+	Falldown = 2;
+	
+	Flammable = 3;
+	Explosive = 0;
+	Meltable = 0;
+	Hardness = 3;
+	
+	Weight = 40;
+	
+	Temperature = R_TEMP+273.15f;
+	HeatConduct = 200;
+	Description = "Freon liquid. Produced from compression of freon gas. State transitions allow controlled heat flow.";
+	
+	State = ST_LIQUID;
+	Properties = TYPE_LIQUID|PROP_DEADLY;
+
+	LowPressure = IPL;
+    LowPressureTransition = NT;
+    HighPressure = IPH;
+    HighPressureTransition = NT;
+    LowTemperature = ITL;
+    LowTemperatureTransition = NT;
+    HighTemperature = ITH;
+    HighTemperatureTransition = NT;
+	
+	Update = &Element_FRNL::update;
+	
+}
+
+//#TPT-Directive ElementHeader Element_FRNL static int update(UPDATE_FUNC_ARGS)
+int Element_FRNL::update(UPDATE_FUNC_ARGS)
+ {
+	 if (sim->pv[y/CELL][x/CELL] < 15.0f)
+	{
+		parts[i].tmp = parts[i].temp - (273.15f - 50.0f); //tmp is the difference
+		parts[i].temp = 273.15f - 50.0f; //Newly decompressed freon liquid should start off at -50 C
+		sim->part_change_type(i, parts[i].x, parts[i].y, PT_FREN); //Can't use normal transitions due to the above code needing to run first
+	}
+	return 0;
+}
+
+Element_FRNL::~Element_FRNL() {}

--- a/src/simulation/elements/FRNL.cpp
+++ b/src/simulation/elements/FRNL.cpp
@@ -28,7 +28,7 @@ Element_FRNL::Element_FRNL()
 	
 	Temperature = R_TEMP+273.15f;
 	HeatConduct = 200;
-	Description = "Freon liquid. Produced from compression of freon gas. State transitions allow controlled heat flow.";
+	Description = "Freon liquid. Can be produced from compression of freon gas. State transitions allow controlled heat flow.";
 	
 	State = ST_LIQUID;
 	Properties = TYPE_LIQUID|PROP_DEADLY;

--- a/src/simulation/elements/FRNL.cpp
+++ b/src/simulation/elements/FRNL.cpp
@@ -5,7 +5,7 @@ Element_FRNL::Element_FRNL()
 	Identifier = "DEFAULT_PT_FRNL";
 	Name = "FRNL";
 	Colour = PIXPACK(0x6E8B41);
-	MenuVisible = 1;
+	MenuVisible = 0;
 	MenuSection = SC_LIQUID;
 	Enabled = 1;
 	
@@ -28,7 +28,7 @@ Element_FRNL::Element_FRNL()
 	
 	Temperature = R_TEMP+273.15f;
 	HeatConduct = 200;
-	Description = "Freon liquid. Can be produced from compression of freon gas. State transitions allow controlled heat flow.";
+	Description = "Freon liquid. Gaseous at normal pressure. State transitions allow controlled heat flow.";
 	
 	State = ST_LIQUID;
 	Properties = TYPE_LIQUID|PROP_DEADLY;
@@ -49,10 +49,10 @@ Element_FRNL::Element_FRNL()
 //#TPT-Directive ElementHeader Element_FRNL static int update(UPDATE_FUNC_ARGS)
 int Element_FRNL::update(UPDATE_FUNC_ARGS)
  {
-	 if (sim->pv[y/CELL][x/CELL] < 15.0f)
+	if (sim->pv[y/CELL][x/CELL] < 15.0f)
 	{
-		parts[i].tmp = parts[i].temp - (273.15f - 50.0f); //tmp is the difference
-		parts[i].temp = 273.15f - 50.0f; //Newly decompressed freon liquid should start off at -50 C
+		parts[i].temp -= parts[i].tmp;
+		parts[i].tmp = 0;
 		sim->part_change_type(i, parts[i].x, parts[i].y, PT_FREN); //Can't use normal transitions due to the above code needing to run first
 	}
 	return 0;


### PR DESCRIPTION
These are two elements designed for use as refrigerants. They changed state based and pressure (similar to GAS and OIL), and change temperature based on their state changes.

* Both look like a dark, dingy green, with FRNL being slightly darker.
* When FREN is compressed (>15), it stores the pressure it was under in its tmp (this can be higher than 15, if you use TTAN or airblock wall) and adds that pressure to its temperature.
* When FRNL is decompressed (<15), it subtracts its tmp from its temperature and sets its tmp to zero. This way, if you cool off compressed freon, you can end up with a much colder freon gas.
* FREN and FRNL are toxic to stickmen.
* FREN will destroy O2 in a similar manner to CO2 destroying fire. (Freon is actually a class of chemicals that includes CFCs, the chemicals responsible for ozone destruction)
* FREN acts like a cross between BOYL and FOG (although it isn't) in terms of gas movement and characteristics.
* FRNL is pretty much a clone of WATR, but heavier.
* Both FREN and FRNL have a heat conductivity of 200, making them superb heat conductors, which is what they are supposed to be.
* FREN is slightly flammable (value of 3, I think). It'll burn at a slower-than-decent rate, but you wouldn't want to use it as a fuel.

So the big question is, what use would we have for these elements? **Heat pumps!** There is no proper heat pump in TPT that *actively* transfers heat - everything is passive so far, purely reliant on differences in temperatures. We have GLOW heat transfer, sure, but it's just another passive heat moving thing.

 With FREN and FRNL, you can actively pump heat from one point to another. This has the benefit of being able to move far more heat that a regular, passive heat pump. For example, you could make a proper reactor heat pump, or an ultra-efficient power station that uses as much heat as it can. Alternatively, you could look on the "cool" side, and make a more realistic deuterium compressor that doesn't use LIFE or CLNE to cool down the deuterium.