### PR TITLE
SConscript: Fix some inconsistencies

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -17,7 +17,7 @@ class ourSpawn:
 		startupinfo = subprocess.STARTUPINFO()
 		startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 		proc = subprocess.Popen(cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-			stderr=subprocess.PIPE, startupinfo=startupinfo, shell = False, env = env)
+			stderr=subprocess.PIPE, startupinfo=startupinfo, shell=False, env=env)
 		data, err = proc.communicate()
 		rv = proc.wait()
 		if rv:
@@ -95,11 +95,11 @@ if msvc and platform != "Windows":
 
 #Create SCons Environment
 if GetOption('msvc'):
-	env = Environment(tools = ['default'], ENV = {'PATH' : os.environ['PATH'], 'TMP' : os.environ['TMP']}, TARGET_ARCH = 'x86')
+	env = Environment(tools=['default'], ENV={'PATH' : os.environ['PATH'], 'TMP' : os.environ['TMP']}, TARGET_ARCH='x86')
 elif platform == "Windows" and not GetOption('msvc'):
-	env = Environment(tools = ['mingw'], ENV = {'PATH' : os.environ['PATH']})
+	env = Environment(tools=['mingw'], ENV={'PATH' : os.environ['PATH']})
 else:
-	env = Environment(tools = ['default'], ENV = {'PATH' : os.environ['PATH']})
+	env = Environment(tools=['default'], ENV={'PATH' : os.environ['PATH']})
 
 #attempt to automatically find cross compiler
 if not tool and compilePlatform == "Linux" and compilePlatform != platform:


### PR DESCRIPTION
According to [this section of PEP8](https://www.python.org/dev/peps/pep-0008/#other-recommendations), it is incorrect, 
> * Don't use spaces around the = sign when used to indicate a keyword argument or a default parameter value.

and it would be inconsistent with the rest of the code.