### PR TITLE
Add element names to the start of description strings

### DIFF
--- a/src/simulation/elements/ACID.cpp
+++ b/src/simulation/elements/ACID.cpp
@@ -28,7 +28,7 @@ Element_ACID::Element_ACID()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 34;
-	Description = "Dissolves almost everything.";
+	Description = "Acid. Dissolves almost everything.";
 
 	Properties = TYPE_LIQUID|PROP_DEADLY;
 

--- a/src/simulation/elements/AMTR.cpp
+++ b/src/simulation/elements/AMTR.cpp
@@ -28,7 +28,7 @@ Element_AMTR::Element_AMTR()
 
 	Temperature = R_TEMP+0.0f +273.15f;
 	HeatConduct = 70;
-	Description = "Anti-Matter, destroys a majority of particles.";
+	Description = "Antimatter. Destroys a majority of particles.";
 
 	Properties = TYPE_GAS;
 

--- a/src/simulation/elements/BTRY.cpp
+++ b/src/simulation/elements/BTRY.cpp
@@ -28,7 +28,7 @@ Element_BTRY::Element_BTRY()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Generates infinite electricity.";
+	Description = "Battery. Generates infinite electricity.";
 
 	Properties = TYPE_SOLID;
 

--- a/src/simulation/elements/CLNE.cpp
+++ b/src/simulation/elements/CLNE.cpp
@@ -28,7 +28,7 @@ Element_CLNE::Element_CLNE()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Solid. Duplicates any particles it touches.";
+	Description = "Clone. Starts making the particle it first touches.";
 
 	Properties = TYPE_SOLID|PROP_DRAWONCTYPE|PROP_NOCTYPEDRAW;
 

--- a/src/simulation/elements/CONV.cpp
+++ b/src/simulation/elements/CONV.cpp
@@ -28,7 +28,7 @@ Element_CONV::Element_CONV()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Solid. Converts everything into whatever it first touches.";
+	Description = "Converter. Converts everything into whatever it first touches.";
 
 	Properties = TYPE_SOLID|PROP_DRAWONCTYPE|PROP_NOCTYPEDRAW;
 

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -28,7 +28,7 @@ Element_FIRE::Element_FIRE()
 
 	Temperature = R_TEMP+400.0f+273.15f;
 	HeatConduct = 88;
-	Description = "Ignites flammable materials. Heats air.";
+	Description = "Fire. Ignites flammable materials. Heats air.";
 
 	Properties = TYPE_GAS|PROP_LIFE_DEC|PROP_LIFE_KILL;
 

--- a/src/simulation/elements/FUSE.cpp
+++ b/src/simulation/elements/FUSE.cpp
@@ -28,7 +28,7 @@ Element_FUSE::Element_FUSE()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 200;
-	Description = "Burns slowly. Ignites at somewhat high temperatures or with electricity.";
+	Description = "Fuse. Burns slowly. Ignites at somewhat high temperatures or with electricity.";
 
 	Properties = TYPE_SOLID;
 

--- a/src/simulation/elements/GAS.cpp
+++ b/src/simulation/elements/GAS.cpp
@@ -28,7 +28,7 @@ Element_GAS::Element_GAS()
 
 	Temperature = R_TEMP+2.0f	+273.15f;
 	HeatConduct = 42;
-	Description = "Diffuses quickly and flammable. Liquefies into OIL under pressure.";
+	Description = "Gas. Diffuses quickly and is flammable. Liquefies into OIL under pressure.";
 
 	Properties = TYPE_GAS | PROP_NEUTPASS;
 

--- a/src/simulation/elements/GOLD.cpp
+++ b/src/simulation/elements/GOLD.cpp
@@ -29,7 +29,7 @@ Element_GOLD::Element_GOLD()
 
 	Temperature = R_TEMP+0.0f +273.15f;
 	HeatConduct = 251;
-	Description = "Corrosion resistant metal, will reverse corrosion of iron.";
+	Description = "Gold. Corrosion resistant metal, will reverse corrosion of iron.";
 
 	Properties = TYPE_SOLID|PROP_CONDUCTS|PROP_HOT_GLOW|PROP_LIFE_DEC|PROP_NEUTPASS;
 

--- a/src/simulation/elements/GOO.cpp
+++ b/src/simulation/elements/GOO.cpp
@@ -28,7 +28,7 @@ Element_GOO::Element_GOO()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 75;
-	Description = "Deforms and disappears under pressure.";
+	Description = "Goo. Deforms and disappears under pressure.";
 
 	Properties = TYPE_SOLID | PROP_NEUTPENETRATE|PROP_LIFE_DEC|PROP_LIFE_KILL_DEC;
 

--- a/src/simulation/elements/ICEI.cpp
+++ b/src/simulation/elements/ICEI.cpp
@@ -28,7 +28,7 @@ Element_ICEI::Element_ICEI()
 
 	Temperature = R_TEMP-50.0f+273.15f;
 	HeatConduct = 46;
-	Description = "Crushes under pressure. Cools down air.";
+	Description = "Ice. Crushes under pressure. Cools down air.";
 
 	Properties = TYPE_SOLID|PROP_LIFE_DEC|PROP_NEUTPASS;
 

--- a/src/simulation/elements/IRON.cpp
+++ b/src/simulation/elements/IRON.cpp
@@ -28,7 +28,7 @@ Element_IRON::Element_IRON()
 
 	Temperature = R_TEMP+0.0f +273.15f;
 	HeatConduct = 251;
-	Description = "Rusts with salt, can be used for electrolysis of WATR.";
+	Description = "Iron. Rusts with salt, can be used for electrolysis of WATR.";
 
 	Properties = TYPE_SOLID|PROP_CONDUCTS|PROP_LIFE_DEC|PROP_HOT_GLOW;
 

--- a/src/simulation/elements/METL.cpp
+++ b/src/simulation/elements/METL.cpp
@@ -28,7 +28,7 @@ Element_METL::Element_METL()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "The basic conductor. Meltable.";
+	Description = "Metal. The most basic conductor. Meltable.";
 
 	Properties = TYPE_SOLID|PROP_CONDUCTS|PROP_LIFE_DEC|PROP_HOT_GLOW;
 

--- a/src/simulation/elements/NTCT.cpp
+++ b/src/simulation/elements/NTCT.cpp
@@ -28,7 +28,7 @@ Element_NTCT::Element_NTCT()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Semi-conductor. Only conducts electricity when hot. (More than 100C)";
+	Description = "N-type thermistor. Only conducts electricity when hot. (More than 100C)";
 
 	Properties = TYPE_SOLID|PROP_CONDUCTS|PROP_LIFE_DEC;
 

--- a/src/simulation/elements/OIL.cpp
+++ b/src/simulation/elements/OIL.cpp
@@ -28,7 +28,7 @@ Element_OIL::Element_OIL()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 42;
-	Description = "Flammable, turns into GAS at low pressure or high temperature. Can be formed with NEUT and NITR.";
+	Description = "Oil. Flammable, turns into GAS at low pressure or high temperature. Can be formed with NEUT and NITR.";
 
 	Properties = TYPE_LIQUID | PROP_NEUTPASS;
 

--- a/src/simulation/elements/PLEX.cpp
+++ b/src/simulation/elements/PLEX.cpp
@@ -28,7 +28,7 @@ Element_PLEX::Element_PLEX()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 88;
-	Description = "Solid pressure sensitive explosive.";
+	Description = "C4. Solid pressure sensitive explosive.";
 
 	Properties = TYPE_SOLID | PROP_NEUTPENETRATE;
 

--- a/src/simulation/elements/PLUT.cpp
+++ b/src/simulation/elements/PLUT.cpp
@@ -28,7 +28,7 @@ Element_PLUT::Element_PLUT()
 
 	Temperature = R_TEMP+4.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Heavy particles. Fissile. Generates neutrons under pressure.";
+	Description = "Plutonium. Heavy particles. Fissile. Generates neutrons under pressure.";
 
 	Properties = TYPE_PART|PROP_NEUTPASS|PROP_RADIOACTIVE;
 

--- a/src/simulation/elements/PSTE.cpp
+++ b/src/simulation/elements/PSTE.cpp
@@ -28,7 +28,7 @@ Element_PSTE::Element_PSTE()
 
 	Temperature = R_TEMP-2.0f	+273.15f;
 	HeatConduct = 29;
-	Description = "Colloid, Hardens under pressure.";
+	Description = "Paste. Colloid, Hardens under pressure.";
 
 	Properties = TYPE_LIQUID;
 

--- a/src/simulation/elements/PTCT.cpp
+++ b/src/simulation/elements/PTCT.cpp
@@ -28,7 +28,7 @@ Element_PTCT::Element_PTCT()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Semi-conductor. Only conducts electricity when cold. (Less than 100C)";
+	Description = "P-type thermistor. Only conducts electricity when cold. (Less than 100C)";
 
 	Properties = TYPE_SOLID|PROP_CONDUCTS|PROP_LIFE_DEC;
 

--- a/src/simulation/elements/SNOW.cpp
+++ b/src/simulation/elements/SNOW.cpp
@@ -28,7 +28,7 @@ Element_SNOW::Element_SNOW()
 
 	Temperature = R_TEMP-30.0f+273.15f;
 	HeatConduct = 46;
-	Description = "Light particles. Created when ICE breaks under pressure.";
+	Description = "Snow. Light particles. Created when ICE breaks under pressure.";
 
 	Properties = TYPE_PART|PROP_LIFE_DEC|PROP_NEUTPASS;
 

--- a/src/simulation/elements/STNE.cpp
+++ b/src/simulation/elements/STNE.cpp
@@ -28,7 +28,7 @@ Element_STNE::Element_STNE()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 150;
-	Description = "Heavy particles. Meltable.";
+	Description = "Stones. Heavy particles. Meltable.";
 
 	Properties = TYPE_PART;
 

--- a/src/simulation/elements/STOR.cpp
+++ b/src/simulation/elements/STOR.cpp
@@ -28,7 +28,7 @@ Element_STOR::Element_STOR()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 0;
-	Description = "Captures and stores a single particle. releases when charged with PSCN, also passes to PIPE.";
+	Description = "Storage. Captures and stores a single particle. Releases when charged with PSCN, also passes to PIPE.";
 
 	Properties = TYPE_SOLID|PROP_NOCTYPEDRAW;
 

--- a/src/simulation/elements/SWCH.cpp
+++ b/src/simulation/elements/SWCH.cpp
@@ -28,7 +28,7 @@ Element_SWCH::Element_SWCH()
 
 	Temperature = R_TEMP+0.0f	+273.15f;
 	HeatConduct = 251;
-	Description = "Only conducts when switched on. (PSCN switches on, NSCN switches off)";
+	Description = "Switch. Only conducts when switched on. (PSCN switches on, NSCN switches off)";
 
 	Properties = TYPE_SOLID;
 

--- a/src/simulation/elements/URAN.cpp
+++ b/src/simulation/elements/URAN.cpp
@@ -28,7 +28,7 @@ Element_URAN::Element_URAN()
 
 	Temperature = R_TEMP+30.0f+273.15f;
 	HeatConduct = 251;
-	Description = "Heavy particles. Generates heat under pressure.";
+	Description = "Uranium. Heavy particles. Generates heat under pressure.";
 
 	Properties = TYPE_PART | PROP_RADIOACTIVE;
 

--- a/src/simulation/elements/WATR.cpp
+++ b/src/simulation/elements/WATR.cpp
@@ -28,7 +28,7 @@ Element_WATR::Element_WATR()
 
 	Temperature = R_TEMP-2.0f	+273.15f;
 	HeatConduct = 29;
-	Description = "Conducts electricity, freezes, and extinguishes fires.";
+	Description = "Water. Conducts electricity, freezes, and extinguishes fires.";
 
 	Properties = TYPE_LIQUID|PROP_CONDUCTS|PROP_LIFE_DEC|PROP_NEUTPASS;
 

--- a/src/simulation/elements/WTRV.cpp
+++ b/src/simulation/elements/WTRV.cpp
@@ -28,7 +28,7 @@ Element_WTRV::Element_WTRV()
 
 	Temperature = R_TEMP+100.0f+273.15f;
 	HeatConduct = 48;
-	Description = "Steam. Produced from hot water.";
+	Description = "Water vapour. Produced from hot water.";
 
 	Properties = TYPE_GAS;
 


### PR DESCRIPTION
Some description strings didn't have the element name in them, so for consistency I just added them in. Even stuff with really obvious four-letter names like FIRE or WATR :P

Note, I also changed NTCT/PTCT's names to reflect what the acronym means. It doesn't actually make the element harder to use, and helps users make sense of the cryptic four-letter names.

I also changed more than adding just the name for GAS and CLNE, since the sentence felt sloppy for the first and the CLNE sentence didn't really reflect what it did. I used a similar sentence to CRAY for CLNE with it making the element it first touches. 