### PR TITLE
Fixed segfault

### DIFF
--- a/src/client/DownloadManager.cpp
+++ b/src/client/DownloadManager.cpp
@@ -38,7 +38,11 @@ void DownloadManager::Shutdown()
 	managerShutdown = true;
 	pthread_mutex_unlock(&downloadAddLock);
 	pthread_mutex_unlock(&downloadLock);
-	pthread_join(downloadThread, NULL);
+
+	// Avoid SIGSEGV in case of downloadThread being NULL
+
+	if (downloadThread)
+		pthread_join(downloadThread, NULL);
 }
 
 //helper function for download


### PR DESCRIPTION
On exit, `downloadThread` might be null - that causes a segmentation fault. Even if that doesn't affect anything, it's still nasty.