### PR TITLE
Added a favorites menu.

### DIFF
--- a/src/gui/elementsearch/ElementSearchActivity.cpp
+++ b/src/gui/elementsearch/ElementSearchActivity.cpp
@@ -129,9 +129,9 @@ void ElementSearchActivity::searchTools(std::string query)
 		ToolButton * tempButton;
 
 		if(tempTexture)
-			tempButton = new ToolButton(current+viewPosition, ui::Point(30, 18), "", tool->GetDescription());
+			tempButton = new ToolButton(current+viewPosition, ui::Point(30, 18), "", tool->GetIdentifier(), tool->GetDescription());
 		else
-			tempButton = new ToolButton(current+viewPosition, ui::Point(30, 18), tool->GetName(), tool->GetDescription());
+			tempButton = new ToolButton(current+viewPosition, ui::Point(30, 18), tool->GetName(), tool->GetIdentifier(), tool->GetDescription());
 
 		tempButton->Appearance.SetTexture(tempTexture);
 		tempButton->Appearance.BackgroundInactive = ui::Colour(tool->colRed, tool->colGreen, tool->colBlue);

--- a/src/gui/game/Favorite.cpp
+++ b/src/gui/game/Favorite.cpp
@@ -1,0 +1,26 @@
+﻿#include "Favorite.h"
+#include <algorithm>
+
+std::vector<std::string> *favoritesList;
+
+Favorite::Favorite()
+{
+	favoritesList = new std::vector<std::string>();
+}
+
+
+std::vector<std::string> *Favorite::GetFavoritesList()
+{
+	return favoritesList;
+}
+
+void Favorite::SetFavoritesList(std::vector<std::string> newFavoritesList)
+{
+	*favoritesList = newFavoritesList;
+}
+
+bool Favorite::IsFavorite(std::string identifier)
+{
+	std::vector<std::string> tempFavoritsList = *favoritesList;
+	return std::find(tempFavoritsList.begin(), tempFavoritsList.end(), identifier) != tempFavoritsList.end();
+}

--- a/src/gui/game/Favorite.h
+++ b/src/gui/game/Favorite.h
@@ -1,0 +1,16 @@
+﻿#ifndef FAVORITE_H
+#define FAVORITE_H
+
+#include <string>
+#include <vector>
+
+#include "common/Singleton.h"
+
+class Favorite : public Singleton<Favorite> {
+public:
+	Favorite();
+	std::vector<std::string> * GetFavoritesList();
+	void SetFavoritesList(std::vector<std::string> favoritesList);
+	bool IsFavorite(std::string identifier);
+};
+#endif //FAVORITE_H

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -267,6 +267,11 @@ GameView * GameController::GetView()
 	return gameView;
 }
 
+GameModel* GameController::GetModel()
+{
+	return gameModel;
+}
+
 sign * GameController::GetSignAt(int x, int y)
 {
 	Simulation * sim = gameModel->GetSimulation();

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -267,11 +267,6 @@ GameView * GameController::GetView()
 	return gameView;
 }
 
-GameModel* GameController::GetModel()
-{
-	return gameModel;
-}
-
 sign * GameController::GetSignAt(int x, int y)
 {
 	Simulation * sim = gameModel->GetSimulation();
@@ -1048,6 +1043,11 @@ void GameController::SetActiveMenu(int menuID)
 std::vector<Menu*> GameController::GetMenuList()
 {
 	return gameModel->GetMenuList();
+}
+
+void GameController::RebuildFavoritesMenu()
+{
+	gameModel->BuildFavoritesMenu();
 }
 
 void GameController::ActiveToolChanged(int toolSelection, Tool *tool)

--- a/src/gui/game/GameController.h
+++ b/src/gui/game/GameController.h
@@ -57,7 +57,6 @@ public:
 	GameController();
 	~GameController();
 	GameView * GetView();
-	GameModel * GetModel();
 	sign * GetSignAt(int x, int y);
 
 	bool MouseMove(int x, int y, int dx, int dy);
@@ -104,6 +103,7 @@ public:
 	void SetDebugFlags(unsigned int flags) { debugFlags = flags; }
 	void SetActiveMenu(int menuID);
 	std::vector<Menu*> GetMenuList();
+	void RebuildFavoritesMenu();
 	Tool * GetActiveTool(int selection);
 	void SetActiveTool(int toolSelection, Tool * tool);
 	void SetLastTool(Tool * tool);

--- a/src/gui/game/GameController.h
+++ b/src/gui/game/GameController.h
@@ -57,6 +57,7 @@ public:
 	GameController();
 	~GameController();
 	GameView * GetView();
+	GameModel * GetModel();
 	sign * GetSignAt(int x, int y);
 
 	bool MouseMove(int x, int y, int dx, int dy);

--- a/src/gui/game/GameModel.h
+++ b/src/gui/game/GameModel.h
@@ -125,6 +125,7 @@ public:
 	std::string GetInfoTip();
 
 	void BuildMenus();
+	void BuildFavoritesMenu();
 	void BuildQuickOptionMenu(GameController * controller);
 
 	std::deque<Snapshot*> GetHistory();

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -548,7 +548,7 @@ public:
 			else if (sender->GetSelectionState() == 2)
 				v->c->SetActiveMenu(SC_FAVORITES);
 
-			v->c->GetModel()->BuildFavoritesMenu();
+			v->c->RebuildFavoritesMenu();
 		}
 		else
 		{

--- a/src/gui/game/Menu.h
+++ b/src/gui/game/Menu.h
@@ -45,6 +45,11 @@ public:
 	{
 		tools.push_back(tool_);
 	}
+
+	void ClearTools()
+	{
+		tools.clear();
+	}
 };
 
 

--- a/src/gui/game/ToolButton.cpp
+++ b/src/gui/game/ToolButton.cpp
@@ -1,11 +1,14 @@
 #include "ToolButton.h"
 #include "gui/interface/Keys.h"
+#include "Favorite.h"
 
-ToolButton::ToolButton(ui::Point position, ui::Point size, std::string text_, std::string toolTip):
-	ui::Button(position, size, text_, toolTip)
+ToolButton::ToolButton(ui::Point position, ui::Point size, std::string text_, std::string toolIdentifier, std::string toolTip):
+	ui::Button(position, size, text_, toolTip),
+	toolIdentifier(toolIdentifier)
 {
 	SetSelectionState(-1);
 	Appearance.BorderActive = ui::Colour(255, 0, 0);
+	Appearance.BorderFavorite = ui::Colour(255, 255, 0);
 
 	//don't use "..." on elements that have long names
 	buttonDisplayText = ButtonText.substr(0, 7);
@@ -55,6 +58,10 @@ void ToolButton::Draw(const ui::Point& screenPos)
 	if (isMouseInside && currentSelection == -1)
 	{
 		g->drawrect(screenPos.X, screenPos.Y, Size.X, Size.Y, Appearance.BorderActive.Red, Appearance.BorderActive.Green, Appearance.BorderActive.Blue, Appearance.BorderActive.Alpha);
+	}
+	else if (Favorite::Ref().IsFavorite(toolIdentifier) && currentSelection == -1)
+	{
+		g->drawrect(screenPos.X, screenPos.Y, Size.X, Size.Y, Appearance.BorderFavorite.Red, Appearance.BorderFavorite.Green, Appearance.BorderFavorite.Blue, Appearance.BorderFavorite.Alpha);
 	}
 	else
 	{

--- a/src/gui/game/ToolButton.h
+++ b/src/gui/game/ToolButton.h
@@ -6,8 +6,9 @@
 class ToolButton: public ui::Button
 {
 	int currentSelection;
+	std::string toolIdentifier;
 public:
-	ToolButton(ui::Point position, ui::Point size, std::string text_, std::string toolTip = "");
+	ToolButton(ui::Point position, ui::Point size, std::string text_, std::string toolIdentifier, std::string toolTip = "");
 	virtual void OnMouseUnclick(int x, int y, unsigned int button);
 	virtual void OnMouseUp(int x, int y, unsigned int button);
 	virtual void OnMouseClick(int x, int y, unsigned int button);

--- a/src/gui/interface/Appearance.h
+++ b/src/gui/interface/Appearance.h
@@ -38,6 +38,7 @@ namespace ui
 		ui::Colour BorderHover;
 		ui::Colour BorderInactive;
 		ui::Colour BorderActive;
+		ui::Colour BorderFavorite;
 		ui::Colour BorderDisabled;
 		
 		ui::Border Margin;

--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -158,6 +158,7 @@ menu_section * LoadMenus(int & menuCount)
 		{"\xD2", "Game Of Life", 0, 1},
 		{"\xD7", "Tools", 0, 1},
 		{"\xE4", "Decoration tools", 0, 1},
+		{ "\xCC", "Favorites", 0, 1 },
 		{"\xC8", "Cracker", 0, 0},
 		{"\xC8", "Cracker!", 0, 0},
 	};

--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -158,7 +158,7 @@ menu_section * LoadMenus(int & menuCount)
 		{"\xD2", "Game Of Life", 0, 1},
 		{"\xD7", "Tools", 0, 1},
 		{"\xE4", "Decoration tools", 0, 1},
-		{ "\xCC", "Favorites", 0, 1 },
+		{"\xCC", "Favorites", 0, 1},
 		{"\xC8", "Cracker", 0, 0},
 		{"\xC8", "Cracker!", 0, 0},
 	};

--- a/src/simulation/SimulationData.h
+++ b/src/simulation/SimulationData.h
@@ -15,9 +15,10 @@
 #define SC_LIFE 12
 #define SC_TOOL 13
 #define SC_DECO 14
-#define SC_CRACKER 15
-#define SC_CRACKER2 16
-#define SC_TOTAL 15
+#define SC_FAVORITES 15
+#define SC_CRACKER 16
+#define SC_CRACKER2 17
+#define SC_TOTAL 16
 
 #define O_WL_WALLELEC	122
 #define O_WL_EWALL		123


### PR DESCRIPTION
This PR adds a favourites menu. I've called it favorites internally due to US english etc, but if you prefer proper english I can change it.

Now, I made this because I was bored - and because it was a heavily sought-after feature back in the day. PowderSim had this, but it was terrible - so here's an actual good favourites menu that doesn't crash the client 32 times a second.

The favourites menu uses the identifier, so if element IDs change it won't matter, and the identifier is saved into the powder.pref file. All elements in the favourites menu have a yellow outline to symbolise favourite. This also allows tools, GOL, walls, etc to be favourites as well - not just standard elements.