### PR TITLE
RPEL should really have a ctype

### DIFF
--- a/src/simulation/elements/RPEL.cpp
+++ b/src/simulation/elements/RPEL.cpp
@@ -30,7 +30,7 @@ Element_RPEL::Element_RPEL()
 	HeatConduct = 0;
 	Description = "Repels or attracts particles based on its temperature.";
 
-	Properties = TYPE_SOLID;
+	Properties = TYPE_SOLID | PROP_DRAWONCTYPE | PROP_NOCTYPEDRAW;
 
 	LowPressure = IPL;
 	LowPressureTransition = NT;
@@ -59,8 +59,10 @@ int Element_RPEL::update(UPDATE_FUNC_ARGS)
 				r = sim->photons[y+ry][x+rx];
 
 			if (r && !(sim->elements[r&0xFF].Properties & TYPE_SOLID)){
-				parts[r>>8].vx += isign(rx)*((parts[i].temp-273.15)/10.0f);
-				parts[r>>8].vy += isign(ry)*((parts[i].temp-273.15)/10.0f);
+				if (!parts[i].ctype || parts[i].ctype == parts[r>>8].type) {
+					parts[r>>8].vx += isign(rx)*((parts[i].temp-273.15)/10.0f);
+					parts[r>>8].vy += isign(ry)*((parts[i].temp-273.15)/10.0f);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
As the title says, I think that RPEL should have a settable ctype so that it attracts or repels only specified particles. Can also be used to create pseudo-"magnets".