### PR TITLE
Increase speed of MIX tool and make it work with liquids

### DIFF
--- a/src/simulation/simtools/Mix.cpp
+++ b/src/simulation/simtools/Mix.cpp
@@ -14,9 +14,12 @@ int Tool_Mix::Perform(Simulation * sim, Particle * cpart, int x, int y, float st
 	if(!thisPart)
 		return 0;
 
+	if(rand() % 100 != 0)
+		return 0;
+
 	int distance = (int)(std::pow(strength, .5f) * 10);
 
-	if(!(sim->elements[thisPart&0xFF].Properties & (TYPE_PART | TYPE_LIQUID)))
+	if(!(sim->elements[thisPart&0xFF].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS)))
 		return 0;
 
 	int newX = x + (rand() % distance) - (distance/2);
@@ -29,7 +32,7 @@ int Tool_Mix::Perform(Simulation * sim, Particle * cpart, int x, int y, float st
 	if(!thatPart)
 		return 0;
 
-	if(!(sim->elements[thatPart&0xFF].Properties & (TYPE_PART | TYPE_LIQUID)))
+	if(!(sim->elements[thatPart&0xFF].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS)))
 		return 0;
 
 	sim->pmap[y][x] = thatPart;

--- a/src/simulation/simtools/Mix.cpp
+++ b/src/simulation/simtools/Mix.cpp
@@ -14,12 +14,9 @@ int Tool_Mix::Perform(Simulation * sim, Particle * cpart, int x, int y, float st
 	if(!thisPart)
 		return 0;
 
-	if(rand() % 100 != 0)
-		return 0;
-
 	int distance = (int)(std::pow(strength, .5f) * 10);
 
-	if(!(sim->elements[thisPart&0xFF].Properties & TYPE_PART))
+	if(!(sim->elements[thisPart&0xFF].Properties & (TYPE_PART | TYPE_LIQUID)))
 		return 0;
 
 	int newX = x + (rand() % distance) - (distance/2);
@@ -32,7 +29,7 @@ int Tool_Mix::Perform(Simulation * sim, Particle * cpart, int x, int y, float st
 	if(!thatPart)
 		return 0;
 
-	if(!(sim->elements[thatPart&0xFF].Properties & TYPE_PART))
+	if(!(sim->elements[thatPart&0xFF].Properties & (TYPE_PART | TYPE_LIQUID)))
 		return 0;
 
 	sim->pmap[y][x] = thatPart;


### PR DESCRIPTION
I like the idea of the new MIX tool, but I think it is just too slow to be useful and also does not work with liquids. I removed `if(rand() % 100 != 0)  return 0;` and added TYPE_LIQUID to the acceptable particle types. This makes it work for missing CLST + WATR, GLOW + WATR, and possibly others that I have not thought about yet.