### PR TITLE
fix resume simulation/reload in the middle of subframe debugging

### DIFF
--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -1437,6 +1437,11 @@ void GameController::ChangeBrush()
 	gameModel->SetBrushID(gameModel->GetBrushID()+1);
 }
 
+void GameController::CompleteDebugUpdateParticles()
+{
+    gameModel->CompleteDebugUpdateParticles();
+}
+
 void GameController::ClearSim()
 {
 	gameModel->SetSave(NULL);

--- a/src/gui/game/GameController.h
+++ b/src/gui/game/GameController.h
@@ -132,6 +132,7 @@ public:
 	void OpenElementSearch();
 	void OpenColourPicker();
 	void PlaceSave(ui::Point position);
+    void CompleteDebugUpdateParticles();
 	void ClearSim();
 	void ReloadSim();
 	void Vote(int direction);

--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -905,6 +905,16 @@ void GameModel::FrameStep(int frames)
 	sim->framerender += frames;
 }
 
+void GameModel::CompleteDebugUpdateParticles()
+{
+    if (sim->debug_currentParticle != 0)
+    {
+        sim->UpdateParticles(sim->debug_currentParticle, NPART);
+        sim->AfterSim();
+        sim->debug_currentParticle = 0;
+    }
+}
+
 void GameModel::ClearSimulation()
 {
 	//Load defaults

--- a/src/gui/game/GameModel.h
+++ b/src/gui/game/GameModel.h
@@ -164,6 +164,7 @@ public:
 	void SetAHeatEnable(bool aHeat);
 	bool GetGravityGrid();
 	void ShowGravityGrid(bool showGrid);
+    void CompleteDebugUpdateParticles();
 	void ClearSimulation();
 	vector<Menu*> GetMenuList();
 	vector<QuickOption*> GetQuickOptions();

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1417,8 +1417,11 @@ void GameView::OnKeyPress(int key, Uint16 character, bool shift, bool ctrl, bool
 		enableShiftBehaviour();
 		break;
 	case ' ': //Space
+    {
+        c->CompleteDebugUpdateParticles();
 		c->SetPaused();
 		break;
+    }
 	case 'z':
 		if (selectMode != SelectNone && isMouseDown)
 			break;

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1902,6 +1902,7 @@ void Simulation::create_arc(int sx, int sy, int dx, int dy, int midpoints, int v
 
 void Simulation::clear_sim(void)
 {
+    debug_currentParticle = 0;
 	emp_decor = 0;
 	emp_trigger_count = 0;
 	signs.clear();


### PR DESCRIPTION
This is a new bug, should I file an issue for this?

Bug description/how to reproduce:
- Open R16K1S60 by LBPHacker
- Enter "tpt.setdebug(0x8)" into the Lua console
- Pause the simulation
- Spark the "START" button
- Position mouse at (140, 210) (it doesn't really matter where as long as it's within the electronics) and press Shift-F on the keyboard (this updates all particles up to the mouse position)
- Resume the simulation
- The save is now clearly broken

This fails because the rest of the particles after debug_currentParticle was not updated before the simulation resumed.