### PR TITLE
Fix segfault

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -4272,7 +4272,7 @@ killed:
 						kill_part(i);
 						continue;
 					}
-					r = pmap[fin_y][fin_x];
+					r = pmap[fin_y % YRES][fin_x % XRES];
 
 					if (((r&0xFF)==PT_PIPE || (r&0xFF) == PT_PPIP) && !(parts[r>>8].tmp&0xFF))
 					{


### PR DESCRIPTION
As shown in http://powdertoy.co.uk/Browse/View.html?ID=2039121, an overflow of those values crashes the game, as it tries accessing memory in excess of the bounds of the array.