### PR TITLE
fix particle debug when unpaused

### DIFF
--- a/src/debug/ParticleDebug.cpp
+++ b/src/debug/ParticleDebug.cpp
@@ -62,6 +62,7 @@ bool ParticleDebug::KeyPress(int key, Uint16 character, bool shift, bool ctrl, b
 {
 	if (key == 'f')
 	{
+		model->SetPaused(1);
 		if (alt)
 		{
 			Debug(0, 0, 0);
@@ -96,7 +97,6 @@ bool ParticleDebug::KeyPress(int key, Uint16 character, bool shift, bool ctrl, b
 			{
 				model->FrameStep(1);
 			}
-			model->SetPaused(1);
 		}
 		return false;
 	}


### PR DESCRIPTION
Another small bugfix. This is different from the previous issue.

In debug mode, when the simulation is _unpaused_, hit Shift-F on any particle in a subframe-heavy save. The save would break.

This fix pauses the simulation when Shift-F (or Alt-F, for that matter) is pressed.