### PR TITLE
Add sim.brush

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1056,6 +1056,11 @@ void GameSave::readOPS(char * data, int dataLength)
 								particles[newIndex].tmp = 6;
 							particles[newIndex].ctype = 0;
 						}
+						if (savedVersion < 92)
+						{
+							if (particles[newIndex].tmp==4 || particles[newIndex].tmp==5)
+								particles[newIndex].ctype = 0;
+						}
 						break;
 					case PT_QRTZ:
 					case PT_PQRT:
@@ -1767,6 +1772,11 @@ void GameSave::readPSv(char * data, int dataLength)
 						particles[i-1].tmp = 0;
 					}
 				}
+			}
+			if (ver < 92)
+			{
+				if (particles[i-1].tmp==4 || particles[i-1].tmp==5)
+					particles[i-1].ctype = 0;
 			}
 		}
 	}

--- a/src/lua/LuaScriptInterface.h
+++ b/src/lua/LuaScriptInterface.h
@@ -102,6 +102,7 @@ class LuaScriptInterface: public CommandInterface
 	static int simulation_elementCount(lua_State * l);
 	static int simulation_canMove(lua_State * l);
 	static int simulation_parts(lua_State * l);
+	static int simulation_brush(lua_State * l);
 	static int simulation_pmap(lua_State * l);
 	static int simulation_photons(lua_State * l);
 	static int simulation_neighbours(lua_State * l);

--- a/src/simulation/elements/FILT.cpp
+++ b/src/simulation/elements/FILT.cpp
@@ -90,13 +90,17 @@ int Element_FILT::interactWavelengths(Particle* cpart, int origWl)
 			return origWl & (~filtWl); //Subtract colour of filt from colour of photon
 		case 4:
 			{
-				int shift = int((cpart->temp-273.0f)*0.025f);
+				int shift = cpart->ctype;
+				if (!shift)
+					shift = int((cpart->temp-273.0f)*0.025f);
 				if (shift<=0) shift = 1;
 				return (origWl << shift) & mask; // red shift
 			}
 		case 5:
 			{
-				int shift = int((cpart->temp-273.0f)*0.025f);
+				int shift = cpart->ctype;
+				if (!shift)
+					shift = int((cpart->temp-273.0f)*0.025f);
 				if (shift<=0) shift = 1;
 				return (origWl >> shift) & mask; // blue shift
 			}


### PR DESCRIPTION
Traverses the coordinates below a copy of the current brush placed at the coordinates passed. Example:

```
for px, py in sim.brush(tpt.mousex, tpt.mousey) do
	local id = sim.partID(px, py)
	if id then
		sim.partProperty(id, "dcolour", 0xFFFF0000)
	end
end
```