### PR TITLE
Fix favorites menu

### DIFF
--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1137,6 +1137,45 @@ void GameView::OnMouseMove(int x, int y, int dx, int dy)
 		c->SetActiveMenu(delayedActiveMenu);
 		delayedActiveMenu = -1;
 	}
+
+	if(toolButtons.size())
+	{
+		int totalWidth = (toolButtons[0]->Size.X+1)*toolButtons.size();
+		int scrollSize = (int)(((float)(XRES-BARSIZE))/((float)totalWidth) * ((float)XRES-BARSIZE));
+		if (scrollSize>XRES-1)
+			scrollSize = XRES-1;
+		if(totalWidth > XRES-15)
+		{
+			int mouseX = x;
+			if(mouseX > XRES)
+				mouseX = XRES;
+			//if (mouseX < 15) //makes scrolling a little nicer at edges but apparently if you put hundreds of elements in a menu it makes the end not show ...
+			//	mouseX = 15;
+
+			scrollBar->Position.X = (int)(((float)mouseX/((float)XRES))*(float)(XRES-scrollSize));
+
+			float overflow = totalWidth-(XRES-BARSIZE), mouseLocation = float(XRES-3)/float(mouseX-(XRES-2)); //mouseLocation adjusted slightly in case you have 200 elements in one menu
+			setToolButtonOffset(overflow/mouseLocation);
+
+			//Ensure that mouseLeave events are make their way to the buttons should they move from underneath the mouse pointer
+			if(toolButtons[0]->Position.Y < y && toolButtons[0]->Position.Y+toolButtons[0]->Size.Y > y)
+			{
+				for(vector<ToolButton*>::iterator iter = toolButtons.begin(), end = toolButtons.end(); iter!=end; ++iter)
+				{
+					ToolButton * button = *iter;
+					if(button->Position.X < x && button->Position.X+button->Size.X > x)
+						button->OnMouseEnter(x, y);
+					else
+						button->OnMouseLeave(x, y);
+				}
+			}
+		}
+		else
+		{
+			scrollBar->Position.X = 1;
+		}
+		scrollBar->Size.X=scrollSize;
+	}
 }
 
 void GameView::OnMouseDown(int x, int y, unsigned button)
@@ -1760,45 +1799,6 @@ void GameView::DoMouseMove(int x, int y, int dx, int dy)
 {
 	if(c->MouseMove(x, y, dx, dy))
 		Window::DoMouseMove(x, y, dx, dy);
-
-	if(toolButtons.size())
-	{
-		int totalWidth = (toolButtons[0]->Size.X+1)*toolButtons.size();
-		int scrollSize = (int)(((float)(XRES-BARSIZE))/((float)totalWidth) * ((float)XRES-BARSIZE));
-		if (scrollSize>XRES-1)
-			scrollSize = XRES-1;
-		if(totalWidth > XRES-15)
-		{
-			int mouseX = x;
-			if(mouseX > XRES)
-				mouseX = XRES;
-			//if (mouseX < 15) //makes scrolling a little nicer at edges but apparently if you put hundreds of elements in a menu it makes the end not show ...
-			//	mouseX = 15;
-
-			scrollBar->Position.X = (int)(((float)mouseX/((float)XRES))*(float)(XRES-scrollSize));
-
-			float overflow = totalWidth-(XRES-BARSIZE), mouseLocation = float(XRES-3)/float(mouseX-(XRES-2)); //mouseLocation adjusted slightly in case you have 200 elements in one menu
-			setToolButtonOffset(overflow/mouseLocation);
-
-			//Ensure that mouseLeave events are make their way to the buttons should they move from underneath the mouse pointer
-			if(toolButtons[0]->Position.Y < y && toolButtons[0]->Position.Y+toolButtons[0]->Size.Y > y)
-			{
-				for(vector<ToolButton*>::iterator iter = toolButtons.begin(), end = toolButtons.end(); iter!=end; ++iter)
-				{
-					ToolButton * button = *iter;
-					if(button->Position.X < x && button->Position.X+button->Size.X > x)
-						button->OnMouseEnter(x, y);
-					else
-						button->OnMouseLeave(x, y);
-				}
-			}
-		}
-		else
-		{
-			scrollBar->Position.X = 1;
-		}
-		scrollBar->Size.X=scrollSize;
-	}
 }
 
 void GameView::DoMouseDown(int x, int y, unsigned button)

--- a/src/gui/game/GameView.h
+++ b/src/gui/game/GameView.h
@@ -112,8 +112,7 @@ private:
 
 	SimulationSample sample;
 
-	int lastOffset;
-	void setToolButtonOffset(int offset);
+	void updateToolButtonScroll();
 
 	void SetSaveButtonTooltips();
 


### PR DESCRIPTION
Fixes #322.
1. The tool button offsets were originally updated in DoMouseMove. I moved that to OnMouseMove so that currentMouse would be set (if I'm not wrong, OnMouseMove is called after DoMouseMove). It doesn't seem that it should be in DoMouseMove anyway, since DoMouseMove is apparently supposed to be a "top-level handler, for Lua interface". If necessary, we can always move it back by adding an argument for mouse position in updateToolButtonScroll().
2. The offsets were originally set by remembering the previous offset in lastOffset, then calculating a delta to shift the buttons without disturbing the spacing (looks like a hack for the deco menu). Since the previous offset can be derived from the position of the first tool button, this was redundant, so I removed it (the redundancy made fixing the favorites menu more difficult than it should've been).
   - This would make it harder, in the future, to add menus without a right-flushed tool button. But given a choice between having to hack in a possible future menu and having to hack in a current menu, I'd think the former is more reasonable.
3. (main source of bug) The offsets were originally only recalculated if the menu width is larger than the screen width. This breaks if the menu width was larger than the screen width in one frame, then smaller in the next (as when unfavoriting). I made it such that it recalculates every frame. I don't think performance is a concern here (especially given the rest of the GUI code), but we can always add in an initial check (offsetDelta != 0) if desired.

...I hope I didn't break anything :P
