### PR TITLE
Add sim.brush (again, see #345)

### DIFF
--- a/src/lua/LuaScriptInterface.h
+++ b/src/lua/LuaScriptInterface.h
@@ -102,6 +102,7 @@ class LuaScriptInterface: public CommandInterface
 	static int simulation_elementCount(lua_State * l);
 	static int simulation_canMove(lua_State * l);
 	static int simulation_parts(lua_State * l);
+	static int simulation_brush(lua_State * l);
 	static int simulation_pmap(lua_State * l);
 	static int simulation_photons(lua_State * l);
 	static int simulation_neighbours(lua_State * l);


### PR DESCRIPTION
Traverses the coordinates below a copy of the current brush placed at the coordinates passed. Example:

``` lua
for px, py in sim.brush(tpt.mousex, tpt.mousey) do
    local id = sim.partID(px, py)
    if id then
        sim.partProperty(id, "dcolour", 0xFFFF0000)
    end
end
```

Also, stupid me pushed this feature to master last time, see #345. Fixed.
