### PR TITLE
Add ctype-based FILT shift modes

### DIFF
--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -2293,8 +2293,8 @@ void GameView::OnDraw()
 				else if (type == PT_FILT)
 				{
 					sampleInfo << c->ElementResolve(type, ctype);
-					const char* filtModes[] = {"set colour", "AND", "OR", "subtract colour", "red shift", "blue shift", "no effect", "XOR", "NOT", "old QRTZ scattering"};
-					if (sample.particle.tmp>=0 && sample.particle.tmp<=9)
+					const char* filtModes[] = {"set colour", "AND", "OR", "subtract colour", "red shift", "blue shift", "no effect", "XOR", "NOT", "old QRTZ scattering", "variable red shift", "variable blue shift"};
+					if (sample.particle.tmp>=0 && sample.particle.tmp<=11)
 						sampleInfo << " (" << filtModes[sample.particle.tmp] << ")";
 					else
 						sampleInfo << " (unknown mode)";

--- a/src/simulation/elements/FILT.cpp
+++ b/src/simulation/elements/FILT.cpp
@@ -113,6 +113,16 @@ int Element_FILT::interactWavelengths(Particle* cpart, int origWl)
 			int t3 = ((origWl & 0xFF0000)>>16)+(rand()%5)-2;
 			return (origWl & 0xFF000000) | (t3<<16) | (t2<<8) | t1;
 		}
+		case 10:
+			{
+				long long int lsb = filtWl & (-filtWl);
+				return (origWl * lsb) & 0x3FFFFFFF; //red shift
+			}
+		case 11:
+			{
+				long long int lsb = filtWl & (-filtWl);
+				return (origWl / lsb) & 0x3FFFFFFF; // blue shift
+			}
 		default:
 			return filtWl;
 	}


### PR DESCRIPTION
Use FILT modes 10 and 11 for much friendlier bitshift behaviour. For the sake of physical plausibility, this implementation uses the bluest ("most energetic") wavelength (i.e. least significant bit, as opposed to the binary representation) to determine the bitshift amount.
