### PR TITLE
Fix debug zeroth particle

### DIFF
--- a/src/debug/ParticleDebug.cpp
+++ b/src/debug/ParticleDebug.cpp
@@ -32,7 +32,7 @@ void ParticleDebug::Debug(int mode, int x, int y)
 	}
 	else if (mode == 1)
 	{
-		if (x < 0 || x >= XRES || y < 0 || y >= YRES || !(i = (sim->pmap[y][x]>>8)) || i < debug_currentParticle)
+		if (x < 0 || x >= XRES || y < 0 || y >= YRES || !sim->pmap[y][x] || (i = (sim->pmap[y][x]>>8)) < debug_currentParticle)
 		{
 			i = NPART;
 			logmessage << "Updated particles from #" << debug_currentParticle << " to end, updated sim";


### PR DESCRIPTION
Very small bugfix. Previously, if you try to shift-F the particle with id 0 at the start of a frame in particle debug mode, the whole frame would be updated. This is because the particle id was being used to check the existence of a particle at the mouse location. With this bugfix, only that particle would be updated, as is intended behaviour.
