### PR TITLE
Fix WIFI cooldown

### DIFF
--- a/src/simulation/elements/WIFI.cpp
+++ b/src/simulation/elements/WIFI.cpp
@@ -70,13 +70,10 @@ int Element_WIFI::update(UPDATE_FUNC_ARGS)
 						parts[r>>8].life = 4;
 					}
 				}
-				else
+				if ((r&0xFF)==PT_SPRK && parts[r>>8].ctype!=PT_NSCN && parts[r>>8].life>=3)
 				{
-					if ((r&0xFF)==PT_SPRK && parts[r>>8].ctype!=PT_NSCN && parts[r>>8].life>=3)
-					{
-						sim->wireless[parts[i].tmp][1] = 1;
-						sim->ISWIRE = 2;
-					}
+					sim->wireless[parts[i].tmp][1] = 1;
+					sim->ISWIRE = 2;
 				}
 			}
 	return 0;


### PR DESCRIPTION
For some reason WIFI would only add sparks to the spark queue
(sim->wireless[1]) if there was no spark added to it in the previous
frame (sim->wireless[0] in the current frame). Fixed.