### PR TITLE
Take history snapshot before setting save

### DIFF
--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -51,6 +51,7 @@ public:
 		{
 			try
 			{
+				cc->HistorySnapshot();
 				cc->gameModel->SetSave(cc->search->GetLoadedSave());
 				cc->search->ReleaseLoadedSave();
 			}
@@ -73,6 +74,7 @@ public:
 		{
 			try
 			{
+				cc->HistorySnapshot();
 				cc->LoadSave(cc->activePreview->GetSaveInfo());
 			}
 			catch(GameModelException & ex)
@@ -1252,6 +1254,7 @@ void GameController::OpenLocalBrowse()
 		virtual  ~LocalSaveOpenCallback() {};
 		virtual void FileSelected(SaveFile* file)
 		{
+			c->HistorySnapshot();
 			c->LoadSaveFile(file);
 			delete file;
 		}
@@ -1488,6 +1491,7 @@ void GameController::ChangeBrush()
 
 void GameController::ClearSim()
 {
+	HistorySnapshot();
 	gameModel->SetSave(NULL);
 	gameModel->ClearSimulation();
 }
@@ -1496,10 +1500,12 @@ void GameController::ReloadSim()
 {
 	if(gameModel->GetSave() && gameModel->GetSave()->GetGameSave())
 	{
+		HistorySnapshot();
 		gameModel->SetSave(gameModel->GetSave());
 	}
 	else if(gameModel->GetSaveFile() && gameModel->GetSaveFile()->GetGameSave())
 	{
+		HistorySnapshot();
 		gameModel->SetSaveFile(gameModel->GetSaveFile());
 	}
 }

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -234,23 +234,22 @@ GameController::~GameController()
 void GameController::HistoryRestore()
 {
 	std::deque<Snapshot*> history = gameModel->GetHistory();
-	if (history.size())
+	if (!history.size())
+		return;
+	unsigned int historyPosition = gameModel->GetHistoryPosition();
+	unsigned int newHistoryPosition = std::max((int)historyPosition-1, 0);
+	// When undoing, save the current state as a final redo
+	// This way ctrl+y will always bring you back to the point right before your last ctrl+z
+	if (historyPosition == history.size())
 	{
-		unsigned int historyPosition = gameModel->GetHistoryPosition();
-		unsigned int newHistoryPosition = std::max((int)historyPosition-1, 0);
-		// When undoing, save the current state as a final redo
-		// This way ctrl+y will always bring you back to the point right before your last ctrl+z
-		if (historyPosition == history.size())
-		{
-			Snapshot * newSnap = gameModel->GetSimulation()->CreateSnapshot();
-			delete gameModel->GetRedoHistory();
-			gameModel->SetRedoHistory(newSnap);
-		}
-		Snapshot * snap = history[newHistoryPosition];
-		gameModel->GetSimulation()->Restore(*snap);
-		gameModel->SetHistory(history);
-		gameModel->SetHistoryPosition(newHistoryPosition);
+		Snapshot * newSnap = gameModel->GetSimulation()->CreateSnapshot();
+		delete gameModel->GetRedoHistory();
+		gameModel->SetRedoHistory(newSnap);
 	}
+	Snapshot * snap = history[newHistoryPosition];
+	gameModel->GetSimulation()->Restore(*snap);
+	gameModel->SetHistory(history);
+	gameModel->SetHistoryPosition(newHistoryPosition);
 }
 
 void GameController::HistorySnapshot()

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -146,7 +146,6 @@ GameController::GameController():
 
 	gameView->AttachController(this);
 	gameModel->AddObserver(gameView);
-	gameModel->SetAllowHistory();
 
 	gameView->SetDebugHUD(Client::Ref().GetPrefBool("Renderer.DebugMode", false));
 
@@ -256,11 +255,6 @@ void GameController::HistoryRestore()
 
 void GameController::HistorySnapshot()
 {
-	// callbacks during initialization create two empty snapshots on startup
-	// Prevent that from happening here
-	if (!gameModel->GetAllowHistory())
-		return;
-
 	std::deque<Snapshot*> history = gameModel->GetHistory();
 	unsigned int historyPosition = gameModel->GetHistoryPosition();
 	Snapshot * newSnap = gameModel->GetSimulation()->CreateSnapshot();

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -284,20 +284,19 @@ void GameController::HistorySnapshot()
 void GameController::HistoryForward()
 {
 	std::deque<Snapshot*> history = gameModel->GetHistory();
-	if (history.size())
-	{
-		unsigned int historyPosition = gameModel->GetHistoryPosition();
-		unsigned int newHistoryPosition = std::min((size_t)historyPosition+1, history.size());
-		Snapshot *snap;
-		if (newHistoryPosition == history.size())
-			snap = gameModel->GetRedoHistory();
-		else
-			snap = history[newHistoryPosition];
-		if (!snap)
-			return;
-		gameModel->GetSimulation()->Restore(*snap);
-		gameModel->SetHistoryPosition(newHistoryPosition);
-	}
+	if (!history.size())
+		return;
+	unsigned int historyPosition = gameModel->GetHistoryPosition();
+	unsigned int newHistoryPosition = std::min((size_t)historyPosition+1, history.size());
+	Snapshot *snap;
+	if (newHistoryPosition == history.size())
+		snap = gameModel->GetRedoHistory();
+	else
+		snap = history[newHistoryPosition];
+	if (!snap)
+		return;
+	gameModel->GetSimulation()->Restore(*snap);
+	gameModel->SetHistoryPosition(newHistoryPosition);
 }
 
 GameView * GameController::GetView()

--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -28,7 +28,6 @@ GameModel::GameModel():
 	currentFile(NULL),
 	currentUser(0, ""),
 	toolStrength(1.0f),
-	allowHistory(false),
 	redoHistory(NULL),
 	historyPosition(0),
 	activeColourPreset(0),

--- a/src/gui/game/GameModel.h
+++ b/src/gui/game/GameModel.h
@@ -64,7 +64,6 @@ private:
 	Tool * regularToolset[4];
 	User currentUser;
 	float toolStrength;
-	bool allowHistory;
 	std::deque<Snapshot*> history;
 	Snapshot *redoHistory;
 	unsigned int historyPosition;
@@ -132,8 +131,6 @@ public:
 	void BuildFavoritesMenu();
 	void BuildQuickOptionMenu(GameController * controller);
 
-	bool GetAllowHistory() { return allowHistory; }
-	void SetAllowHistory() { allowHistory = true; }
 	std::deque<Snapshot*> GetHistory();
 	unsigned int GetHistoryPosition();
 	void SetHistory(std::deque<Snapshot*> newHistory);

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1035,7 +1035,6 @@ void GameView::NotifySaveChanged(GameModel * sender)
 	}
 	saveSimulationButton->Enabled = (saveSimulationButtonEnabled || ctrlBehaviour);
 	SetSaveButtonTooltips();
-	c->HistorySnapshot();
 }
 
 void GameView::NotifyBrushChanged(GameModel * sender)


### PR DESCRIPTION
Currently, there is unintended behaviour when undoing across reload/clear.

To reproduce:

1. Local save an empty simulation.
2. Draw two lines.
3. Reload.
4. Undo once. Nothing happens, because this reverts to the history snapshot taken _after_ the reload.
5. Undo once more. One line appears, because **no** history snapshot is taken _just before_ the reload.

Expected: At step 4, two lines should appear.

The original intention, I believe, was to clear the undo queue when a save is loaded. This is broken with multiple undos because HistorySnapshot no longer flushes the undo queue completely. At the same time, I do feel that reloading should be undo-able (I've done that by accident quite a number of times).

My fix puts the HistorySnapshot calls _before_ SetSave/SetSaveFile/ClearSim calls. I didn't do HistorySnapshots for SetSave/SetSaveFile called during local save/upload because those actions shouldn't be undo-able (putting them there just makes for null undos).