### PR TITLE
Fix PSTN Oddity

### DIFF
--- a/src/simulation/elements/PSTN.cpp
+++ b/src/simulation/elements/PSTN.cpp
@@ -198,10 +198,10 @@ int Element_PSTN::CanMoveStack(Simulation * sim, int stackX, int stackY, int dir
 		}
 		else
 		{
-			if (spaces < maxSize && currentPos < maxSize && (!retract || ((r&0xFF) == PT_FRME && posX == stackX && posY == stackY)))
+			if (currentPos - spaces < maxSize && (!retract || ((r&0xFF) == PT_FRME && posX == stackX && posY == stackY)))
 				tempParts[currentPos++] = r>>8;
 			else
-				return spaces;
+				return currentPos;
 		}
 	}
 	if (spaces)

--- a/src/simulation/elements/PSTN.cpp
+++ b/src/simulation/elements/PSTN.cpp
@@ -45,6 +45,19 @@ Element_PSTN::Element_PSTN()
 	Graphics = &Element_PSTN::graphics;
 }
 
+//#TPT-Directive ElementHeader Element_PSTN struct StackData
+struct Element_PSTN::StackData
+{
+	int pushed;
+	int spaces;
+	
+	StackData(int pushed, int spaces):
+		pushed(pushed),
+		spaces(spaces)
+	{
+	}
+};
+
 //#TPT-Directive ElementHeader Element_PSTN static int tempParts[XRES]
 int Element_PSTN::tempParts[XRES];
 
@@ -175,12 +188,12 @@ int Element_PSTN::update(UPDATE_FUNC_ARGS)
 	return 0;
 }
 
-//#TPT-Directive ElementHeader Element_PSTN static int CanMoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block)
-int Element_PSTN::CanMoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block)
+//#TPT-Directive ElementHeader Element_PSTN static StackData CanMoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block)
+Element_PSTN::StackData Element_PSTN::CanMoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block)
 {
 	int posX, posY, r, spaces = 0, currentPos = 0;
 	if (amount <= 0)
-		return 0;
+		return StackData(0, 0);
 	for (posX = stackX, posY = stackY; currentPos < maxSize + amount && currentPos < XRES-1; posX += directionX, posY += directionY)
 	{
 		if (!(posX < XRES && posY < YRES && posX >= 0 && posY >= 0))
@@ -188,7 +201,7 @@ int Element_PSTN::CanMoveStack(Simulation * sim, int stackX, int stackY, int dir
 
 		r = sim->pmap[posY][posX];
 		if (sim->IsWallBlocking(posX, posY, 0) || (block && (r&0xFF) == block))
-			return spaces;
+			return StackData(currentPos - spaces, spaces);
 		if (!r)
 		{
 			spaces++;
@@ -201,20 +214,17 @@ int Element_PSTN::CanMoveStack(Simulation * sim, int stackX, int stackY, int dir
 			if (currentPos - spaces < maxSize && (!retract || ((r&0xFF) == PT_FRME && posX == stackX && posY == stackY)))
 				tempParts[currentPos++] = r>>8;
 			else
-				return currentPos;
+				return StackData(currentPos - spaces, spaces);
 		}
 	}
-	if (spaces)
-		return currentPos;
-	else
-		return 0;
+	return StackData(currentPos - spaces, spaces);
 }
 
 //#TPT-Directive ElementHeader Element_PSTN static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block, bool sticky, int callDepth = 0)
 int Element_PSTN::MoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block, bool sticky, int callDepth)
 {
 	bool foundParts = false;
-	int posX, posY, r, spaces = 0, currentPos = 0;
+	int posX, posY, r;
 	r = sim->pmap[stackY][stackX];
 	if(!callDepth && (r&0xFF) == PT_FRME) {
 		int newY = !!directionX, newX = !!directionY;
@@ -227,9 +237,9 @@ int Element_PSTN::MoveStack(Simulation * sim, int stackX, int stackY, int direct
 			posY = stackY + (c*newY);
 			posX = stackX + (c*newX);
 			if (posX < XRES && posY < YRES && posX >= 0 && posY >= 0 && (sim->pmap[posY][posX]&0xFF) == PT_FRME) {
-				int val = CanMoveStack(sim, posX, posY, realDirectionX, realDirectionY, maxSize, amount, retract, block);
-				if(val < amount)
-					amount = val;
+				int spaces = CanMoveStack(sim, posX, posY, realDirectionX, realDirectionY, maxSize, amount, retract, block).spaces;
+				if(spaces < amount)
+					amount = spaces;
 			} else {
 				maxRight = c;
 				break;
@@ -239,9 +249,9 @@ int Element_PSTN::MoveStack(Simulation * sim, int stackX, int stackY, int direct
 			posY = stackY - (c*newY);
 			posX = stackX - (c*newX);
 			if (posX < XRES && posY < YRES && posX >= 0 && posY >= 0 && (sim->pmap[posY][posX]&0xFF) == PT_FRME) {
-				int val = CanMoveStack(sim, posX, posY, realDirectionX, realDirectionY, maxSize, amount, retract, block);
-				if(val < amount)
-					amount = val;
+				int spaces = CanMoveStack(sim, posX, posY, realDirectionX, realDirectionY, maxSize, amount, retract, block).spaces;
+				if(spaces < amount)
+					amount = spaces;
 			} else {
 				maxLeft = c;
 				break;
@@ -272,6 +282,7 @@ int Element_PSTN::MoveStack(Simulation * sim, int stackX, int stackY, int direct
 			for(int j = 1; j <= amount; j++)
 				sim->kill_part(sim->pmap[stackY+(directionY*-j)][stackX+(directionX*-j)]>>8);
 		bool foundEnd = false;
+		int currentPos = 0;
 		for(posX = stackX, posY = stackY; currentPos < maxSize && currentPos < XRES-1; posX += directionX, posY += directionY) {
 			if (!(posX < XRES && posY < YRES && posX >= 0 && posY >= 0)) {
 				break;
@@ -300,7 +311,8 @@ int Element_PSTN::MoveStack(Simulation * sim, int stackX, int stackY, int direct
 		if(!foundParts && foundEnd)
 			return amount;
 	} else {
-		currentPos = CanMoveStack(sim, stackX, stackY, directionX, directionY, maxSize, amount, retract, block);
+		StackData stackData = CanMoveStack(sim, stackX, stackY, directionX, directionY, maxSize, amount, retract, block);
+		int currentPos = stackData.pushed + stackData.spaces;
 		if(currentPos){
 			//Move particles
 			int possibleMovement = 0;
@@ -321,8 +333,6 @@ int Element_PSTN::MoveStack(Simulation * sim, int stackX, int stackY, int direct
 			}
 			return possibleMovement;
 		}
-		if(!foundParts && spaces)
-			return spaces;
 	}
 	return 0;
 }


### PR DESCRIPTION
This addresses a bug with PSTN, illustrated in id:2067073. This is not a subframe bug. Here's one of the ways to reproduce this bug, in words:

Place the following particles in that order:
[PSTN tmp=2 temp=30C] [PSTN] [INSL] [NONE] [NONE] [INSL]

Activate the piston with PSCN. The piston pushes the INSL exactly one block forward, when you would have expected it to push both INSLs until it reaches its intended extension length of 3.

This is due to two bugs in the code:

1. The check for when the piston should stop extending due to pushing too many particles should be a comparison between the number of particles traversed and tmp. Instead, the number of spaces traversed and the total number of pixels traversed are being compared separately to tmp.
2. The function CanMoveStack is supposed to return the furthest position in the stack pushed by the piston after the push, but instead one line returns the number of spaces traversed (disregarding the particles pushed). The correct return value should be currentPos as evidenced by the return statement after the for loop and the name of the variable that the return value is assigned to in MoveStack.