### PR TITLE
Fix downvote button not being reset when opening a local save

### DIFF
--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1012,7 +1012,7 @@ void GameView::NotifySaveChanged(GameModel * sender)
 		upVoteButton->Appearance.BackgroundDisabled = (ui::Colour(0, 0, 0));
 		upVoteButton->Appearance.BorderDisabled = ui::Colour(100, 100, 100);
 		downVoteButton->Enabled = false;
-		upVoteButton->Appearance.BackgroundDisabled = (ui::Colour(0, 0, 0));
+		downVoteButton->Appearance.BackgroundDisabled = (ui::Colour(0, 0, 0));
 		downVoteButton->Appearance.BorderDisabled = ui::Colour(100, 100, 100);
 		tagSimulationButton->Enabled = false;
 		tagSimulationButton->SetText("[no tags set]");


### PR DESCRIPTION
Just a random bug I noticed. It's easy to reproduce:

* open an online save you downvoted
* open a local save
* tada, now your local save is downvoted