### PR TITLE
More parameters for sim.brush

### DIFF
--- a/src/lua/LuaScriptInterface.cpp
+++ b/src/lua/LuaScriptInterface.cpp
@@ -1921,18 +1921,20 @@ int BrushClosure(lua_State * l)
 	int yield_x, yield_y;
 	while (true)
 	{
-		if (!(y < sizeY)) return 0;
+		if (!(y < sizeY))
+			return 0;
 		if (x < sizeX)
 		{
 			bool yield_coords = false;
-			if(bitmap[(y*sizeX)+x] && (positionX+(x-radiusX) >= 0 && positionY+(y-radiusY) >= 0 && positionX+(x-radiusX) < XRES && positionY+(y-radiusY) < YRES))
+			if (bitmap[(y*sizeX)+x] && (positionX+(x-radiusX) >= 0 && positionY+(y-radiusY) >= 0 && positionX+(x-radiusX) < XRES && positionY+(y-radiusY) < YRES))
 			{
 				yield_coords = true;
 				yield_x = positionX+(x-radiusX);
 				yield_y = positionY+(y-radiusY);
 			}
 			x++;
-			if (yield_coords) break;
+			if (yield_coords)
+				break;
 		}
 		else
 		{
@@ -1953,12 +1955,22 @@ int BrushClosure(lua_State * l)
 
 int LuaScriptInterface::simulation_brush(lua_State * l)
 {
-	// see Simulation::ToolBrush
+	int argCount = lua_gettop(l);
 	int positionX = luaL_checkint(l, 1);
 	int positionY = luaL_checkint(l, 2);
-	int brushradiusX = luaL_checkint(l, 3);
-	int brushradiusY = luaL_checkint(l, 4);
-	int brushID = luaL_checkint(l, 5);
+	int brushradiusX, brushradiusY;
+	if (argCount >= 4 || !luacon_model->GetBrush())
+	{
+		brushradiusX = luaL_checkint(l, 3);
+		brushradiusY = luaL_checkint(l, 4);
+	}
+	else
+	{
+		ui::Point size = luacon_model->GetBrush()->GetSize();
+		brushradiusX = size.X;
+		brushradiusY = size.Y;
+	}
+	int brushID = luaL_optint(l, 5, luacon_model->GetBrushID());
 	
 	vector<Brush *> brushList = luacon_model->GetBrushList();
 	if (brushID < 0 || brushID >= (int)brushList.size())

--- a/src/lua/LuaScriptInterface.cpp
+++ b/src/lua/LuaScriptInterface.cpp
@@ -1978,7 +1978,7 @@ int LuaScriptInterface::simulation_brush(lua_State * l)
 	lua_pushnumber(l, sizeY);
 	lua_pushnumber(l, 0);
 	lua_pushnumber(l, 0);
-	int bitmapSize = sizeX * sizeY;
+	int bitmapSize = sizeX * sizeY * sizeof(unsigned char);
 	void *bitmapCopy = lua_newuserdata(l, bitmapSize);
 	memcpy(bitmapCopy, brushList[brushID]->GetBitmap(), bitmapSize);
 	brushList[brushID]->SetRadius(tempRadius);


### PR DESCRIPTION
`sim.brush` now takes three more arguments: horizontal and vertical radius and brush type. I hadn't known about `tpt.brushx`, `tpt.brushy` and `tpt.brushID` when I made #350.

```Lua
for px, py in sim.brush(tpt.mousex, tpt.mousey, tpt.brushx, tpt.brushy, tpt.brushID) do
    local id = sim.partID(px, py)
    if id then
        sim.partProperty(id, "dcolour", 0xFFFF0000)
    end
end
```

Also, the iterator is a bit safer now that it doesn't dereference shady pointers to brush bitmaps. The brush is only ever accessed in the iterator factory, not in the iterator itself.