### PR TITLE
Fix cache value from Lua graphics functions being ignored

### DIFF
--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -1287,7 +1287,19 @@ void Renderer::render_parts()
 #if !defined(RENDERER) && defined(LUACONSOLE)
 						if (lua_gr_func[t])
 						{
-							luacon_graphicsReplacement(this, &(sim->parts[i]), nx, ny, &pixel_mode, &cola, &colr, &colg, &colb, &firea, &firer, &fireg, &fireb, i);
+							if (luacon_graphicsReplacement(this, &(sim->parts[i]), nx, ny, &pixel_mode, &cola, &colr, &colg, &colb, &firea, &firer, &fireg, &fireb, i))
+							{
+								graphicscache[t].isready = 1;
+								graphicscache[t].pixel_mode = pixel_mode;
+								graphicscache[t].cola = cola;
+								graphicscache[t].colr = colr;
+								graphicscache[t].colg = colg;
+								graphicscache[t].colb = colb;
+								graphicscache[t].firea = firea;
+								graphicscache[t].firer = firer;
+								graphicscache[t].fireg = fireg;
+								graphicscache[t].fireb = fireb;
+							}
 						}
 						else if ((*(elements[t].Graphics))(this, &(sim->parts[i]), nx, ny, &pixel_mode, &cola, &colr, &colg, &colb, &firea, &firer, &fireg, &fireb)) //That's a lot of args, a struct might be better
 #else


### PR DESCRIPTION
The cache value returned by luacon_graphicsReplacement (and thus by any Lua graphics function) has been ignored until now. Fixed.